### PR TITLE
Add paging to item lists

### DIFF
--- a/src/components/boards/BoardList.svelte
+++ b/src/components/boards/BoardList.svelte
@@ -8,6 +8,8 @@
   export let boards = []
   export let showHeadline = false
   export let compactOnly = false
+  export let page = 0
+  export let maxPage = 0
 
   let listView = false
   let boardListStore
@@ -26,6 +28,12 @@
 
   function setListView (val) {
     listView = $boardListStore.listView = val
+  }
+
+  function triggerPaging (newPage) {
+    const url = new URL(window.location)
+    url.searchParams.set('page', newPage)
+    window.location.href = url.toString()
   }
 </script>
 
@@ -88,6 +96,14 @@
   {/if}
 {:else}
   <p class='info'>Žádné diskuze nenalezeny</p>
+{/if}
+
+{#if maxPage > 0}
+  <div class='pagination'>
+    {#each { length: maxPage + 1 } as _, i}
+      <button on:click={() => { triggerPaging(i) }} disabled={i === page}>{i + 1}</button>
+    {/each}
+  </div>
 {/if}
 
 <style>
@@ -207,6 +223,16 @@
         height: 100%;
         padding: 20px;
       }
+
+  .pagination {
+    text-align: center;
+    margin-top: 70px;
+  }
+    .pagination button {
+      margin: 5px;
+      font-size: 22px;
+      padding: 15px 25px;
+    }
 
   @media (max-width: 1200px) {
     .block .name {

--- a/src/components/boards/BoardList.svelte
+++ b/src/components/boards/BoardList.svelte
@@ -230,8 +230,10 @@
   }
     .pagination button {
       margin: 5px;
-      font-size: 22px;
-      padding: 15px 25px;
+      font-size: 18px;
+      padding: 0px;
+      width: 40px;
+      height: 40px;
     }
 
   @media (max-width: 1200px) {

--- a/src/components/games/GameList.svelte
+++ b/src/components/games/GameList.svelte
@@ -288,8 +288,10 @@
   }
     .pagination button {
       margin: 5px;
-      font-size: 22px;
-      padding: 15px 25px;
+      font-size: 18px;
+      padding: 0px;
+      width: 40px;
+      height: 40px;
     }
 
   @media (max-width: 1200px) {

--- a/src/components/games/GameList.svelte
+++ b/src/components/games/GameList.svelte
@@ -10,6 +10,8 @@
   export let games = []
   export let showHeadline = false
   export let showTabs = true
+  export let page = 0
+  export let maxPage = 0
 
   let listView = false
   let gameListStore
@@ -50,6 +52,11 @@
 
   function setSort (e) {
     const newUrl = addURLParam('sort', e.target.value, true)
+    window.location.href = newUrl
+  }
+
+  function triggerPaging (newPage) {
+    const newUrl = addURLParam('page', newPage, true)
     window.location.href = newUrl
   }
 </script>
@@ -136,6 +143,14 @@
   {/if}
 {:else}
   <p class='info'>Žádné hry nenalezeny</p>
+{/if}
+
+{#if maxPage > 0}
+  <div class='pagination'>
+    {#each { length: maxPage + 1 } as _, i}
+      <button on:click={() => { triggerPaging(i) } } disabled={i === page}>{i + 1}</button>
+    {/each}
+  </div>
 {/if}
 
 <style>
@@ -266,6 +281,16 @@
         height: 100%;
         padding: 20px;
       }
+
+  .pagination {
+    text-align: center;
+    margin-top: 70px;
+  }
+    .pagination button {
+      margin: 5px;
+      font-size: 22px;
+      padding: 15px 25px;
+    }
 
   @media (max-width: 1200px) {
     .block .name {

--- a/src/components/works/WorkList.svelte
+++ b/src/components/works/WorkList.svelte
@@ -9,6 +9,8 @@
   export let works = []
   export let activeTab = 'articles'
   export let showHeadline = false
+  export let page = 0
+  export let maxPage = 0
 
   let listView = false
   let workListStore
@@ -38,6 +40,12 @@
 
   function setListView (val) {
     listView = $workListStore.listView = val
+  }
+
+  function triggerPaging (newPage) {
+    const url = new URL(window.location)
+    url.searchParams.set('page', newPage)
+    window.location.href = url.toString()
   }
 </script>
 
@@ -114,6 +122,14 @@
   {/if}
 {:else}
   <p class='info'>Žádná díla nenalezena</p>
+{/if}
+
+{#if maxPage > 0}
+  <div class='pagination'>
+    {#each { length: maxPage + 1 } as _, i}
+      <button on:click={() => { triggerPaging(i) }} disabled={i === page}>{i + 1}</button>
+    {/each}
+  </div>
 {/if}
 
 <style>
@@ -230,6 +246,16 @@
       .category {
         padding-right: 20px;
       }
+
+  .pagination {
+    text-align: center;
+    margin-top: 70px;
+  }
+    .pagination button {
+      margin: 5px;
+      font-size: 22px;
+      padding: 15px 25px;
+    }
 
   /* common */
 

--- a/src/components/works/WorkList.svelte
+++ b/src/components/works/WorkList.svelte
@@ -253,8 +253,10 @@
   }
     .pagination button {
       margin: 5px;
-      font-size: 22px;
-      padding: 15px 25px;
+      font-size: 18px;
+      padding: 0px;
+      width: 40px;
+      height: 40px;
     }
 
   /* common */

--- a/src/pages/boards.astro
+++ b/src/pages/boards.astro
@@ -4,7 +4,11 @@
 
   const { supabase, user } = Astro.locals
 
-  const { data: openBoards, error: openError } = await supabase.from('board_list').select('*').match({ open: true, published: true }).order('id', { ascending: false })
+  const page = parseInt(Astro.url.searchParams.get('page') || '0')
+  const limit = 20
+
+  const { data: openBoards, count: openCount, error: openError } = await supabase.from('board_list').select('*', { count: 'exact' }).match({ open: true, published: true }).order('id', { ascending: false }).range(page * limit, page * limit + limit - 1)
+  const maxPage = Math.ceil(openCount / limit) - 1
   if (openError) { console.error(openError) }
 
   // put boards id 1,2 and 3 at the top of the list
@@ -19,7 +23,7 @@
 ---
 
 <Layout title='Diskuze'>
-  <BoardList {user} boards={openBoards} showHeadline client:load />
+  <BoardList {user} boards={openBoards} {page} {maxPage} showHeadline client:load />
   <h2>Soukromé</h2>
   <BoardList {user} boards={privateBoards} compactOnly client:load />
 </Layout>

--- a/src/pages/games.astro
+++ b/src/pages/games.astro
@@ -7,7 +7,10 @@
   const tab = Astro.url.searchParams.get('tab') || 'open'
   const sort = Astro.url.searchParams.get('sort') || 'new'
 
-  let query = supabase.from('game_list').select('*')
+  const page = parseInt(Astro.url.searchParams.get('page') || '0')
+  const limit = 20
+
+  let query = supabase.from('game_list').select('*', { count: 'exact' })
   switch (tab) {
     case 'open': query.match({ archived: false, published: true, recruitment_open: true }); break
     case 'public': query.match({ archived: false, published: true, open_game: true }); break
@@ -26,10 +29,11 @@
     case 'owner': query.order('owner_name'); break
   }
 
-  const { data: games, error } = await query
+  const { data: games, count, error } = await query.range(page * limit, page * limit + limit - 1)
+  const maxPage = Math.ceil(count / limit) - 1
   if (error) { console.error(error) }
 ---
 
 <Layout title='Hry'>
-  <GameList {user} {games} showHeadline client:only='svelte' />
+  <GameList {user} {games} {page} {maxPage} showHeadline client:only='svelte' />
 </Layout>

--- a/src/pages/works.astro
+++ b/src/pages/works.astro
@@ -5,10 +5,14 @@
   const { supabase, user } = Astro.locals
   const activeTab = Astro.url.searchParams.get('tab') || 'articles'
 
-  const { data: works, error } = await supabase.from('work_list').select('*').eq('published', true)
+  const page = parseInt(Astro.url.searchParams.get('page') || '0')
+  const limit = 20
+
+  const { data: works, count, error } = await supabase.from('work_list').select('*', { count: 'exact' }).eq('published', true).range(page * limit, page * limit + limit - 1)
+  const maxPage = Math.ceil(count / limit) - 1
   if (error) { console.error(error) }
 ---
 
 <Layout title='Tvorba'>
-  <WorkList {user} {works} {activeTab} showHeadline client:load />
+  <WorkList {user} {works} {activeTab} {page} {maxPage} showHeadline client:load />
 </Layout>


### PR DESCRIPTION
## Summary
- paginate games, works and boards in the server routes
- send page data to the list components
- support paging UI in `GameList`, `WorkList` and `BoardList`

------
https://chatgpt.com/codex/tasks/task_e_6841c4e1fbb0832f8d88c275d291ee80