### PR TITLE
Enable image and audio works

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "andor2",
   "type": "module",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "scripts": {
     "dev": "astro dev --host",
     "dev-cloudflare": "wrangler pages dev ./dist --live-reload --compatibility-flag=nodejs_compat",

--- a/src/components/works/Work.svelte
+++ b/src/components/works/Work.svelte
@@ -1,17 +1,26 @@
 <script>
+  import { onMount } from 'svelte'
   import { tooltip } from '@lib/tooltip'
   import { supabase, handleError, getPortraitUrl, getWorkFileUrl } from '@lib/database-browser'
   import { bookmarks } from '@lib/stores'
   import { showSuccess } from '@lib/toasts'
+  import { lightboxImage } from '@lib/stores'
   import Discussion from '@components/Discussion.svelte'
   import EditableLong from '@components/common/EditableLong.svelte'
 
   export let user = {}
   export let data = {}
 
-  const isOwner = user.id === data.owner.id
   let bookmarkId
+  let imageUrl = ''
+  const isOwner = user.id === data.owner.id
   const curatorIds = ['a78d91c6-3af6-4163-befd-e7b5d21d9c0f', 'c3304e31-9687-413f-a478-214c865bf5a2', '2d7898ea-ac7b-4f1b-bf29-a10c28892835', '6d3c87ea-aacc-4fd6-9859-852894fd3092'] // Sargo, Hitomi, Eskel, Eskel localhost
+
+  onMount(() => {
+    if (data.type === 'image') {
+      imageUrl = getWorkFileUrl(data.content)
+    }
+  })
 
   async function addBookmark () {
     const { data: newBookmark, error } = await supabase.from('bookmarks').upsert({ user_id: user.id, work_id: data.id, work_thread: data.thread }, { onConflict: 'user_id, work_id', ignoreDuplicates: true }).select().maybeSingle()
@@ -32,6 +41,11 @@
   function showSettings () {
     window.location.href = `${window.location.pathname}?settings=true`
   }
+
+  function showLightbox () {
+    $lightboxImage = imageUrl
+  }
+
   async function updateWorkContent () {
     const { error } = await supabase.from('works').update({ content: data.content }).eq('id', data.id)
     if (error) { return handleError(error) }
@@ -65,7 +79,7 @@
   {#if data.type === 'text'}
     <EditableLong {user} bind:value={data.content} onSave={updateWorkContent} canEdit={isOwner} allowHtml />
   {:else if data.type === 'image'}
-    <img src={getWorkFileUrl(data.content)} alt={data.name} class='media' />
+    <img src={imageUrl} on:click={showLightbox} alt={data.name} class='media' />
   {:else if data.type === 'audio'}
     <audio controls src={getWorkFileUrl(data.content)} class='media'></audio>
   {/if}
@@ -120,7 +134,8 @@
   .media {
     max-width: 100%;
     display: block;
-    margin: 20px auto;
+    margin: 100px auto;
+    cursor: pointer;
   }
     .portrait {
       display: block;

--- a/src/components/works/Work.svelte
+++ b/src/components/works/Work.svelte
@@ -120,7 +120,7 @@
   .media {
     max-width: 100%;
     display: block;
-    margin: 20px 0;
+    margin: 20px auto;
   }
     .portrait {
       display: block;

--- a/src/components/works/Work.svelte
+++ b/src/components/works/Work.svelte
@@ -1,6 +1,6 @@
 <script>
   import { tooltip } from '@lib/tooltip'
-  import { supabase, handleError, getPortraitUrl } from '@lib/database-browser'
+  import { supabase, handleError, getPortraitUrl, getWorkFileUrl } from '@lib/database-browser'
   import { bookmarks } from '@lib/stores'
   import { showSuccess } from '@lib/toasts'
   import Discussion from '@components/Discussion.svelte'
@@ -62,7 +62,13 @@
     {/if}
   </div>
 
-  <EditableLong {user} bind:value={data.content} onSave={updateWorkContent} canEdit={isOwner} allowHtml />
+  {#if data.type === 'text'}
+    <EditableLong {user} bind:value={data.content} onSave={updateWorkContent} canEdit={isOwner} allowHtml />
+  {:else if data.type === 'image'}
+    <img src={getWorkFileUrl(data.content)} alt={data.name} class='media' />
+  {:else if data.type === 'audio'}
+    <audio controls src={getWorkFileUrl(data.content)} class='media'></audio>
+  {/if}
   <div class='details'>
     <div class='date'>Vydáno: {new Date(data.created_at).toLocaleDateString('cs')}</div>
     <div class='author'>
@@ -110,6 +116,11 @@
     display: flex;
     align-items: center;
     gap: 10px;
+  }
+  .media {
+    max-width: 100%;
+    display: block;
+    margin: 20px 0;
   }
     .portrait {
       display: block;

--- a/src/components/works/WorkForm.svelte
+++ b/src/components/works/WorkForm.svelte
@@ -4,25 +4,37 @@
   import TextareaExpandable from '@components/common/TextareaExpandable.svelte'
 
   export let user = {}
+  export let type = 'text'
   let editorRef
   let selectedTags
   let maxTags
   let contentInputRef
   let tagsInputRef
+  let fileInputRef
+  let files
+  let previewUrl
 
   const prepareData = async (event) => {
     event.preventDefault()
-    contentInputRef.value = await editorRef.getContent()
+    if (type === 'text') {
+      contentInputRef.value = await editorRef.getContent()
+    }
     tagsInputRef.value = selectedTags?.length ? selectedTags.map(tag => tag.value).join(',') : null
     event.target.submit()
   }
 
   $: maxTags = selectedTags?.length === 3
   $: tagItems = maxTags ? [] : [...workTags]
+
+  function showPreview () {
+    if (files && files[0]) {
+      previewUrl = URL.createObjectURL(files[0])
+    }
+  }
 </script>
 
 {#if user.id}
-  <form method='POST' autocomplete='off' on:submit={prepareData}>
+  <form method='POST' autocomplete='off' enctype='multipart/form-data' on:submit={prepareData}>
     <div class='row'>
       <div class='labels'>
         <label for='workName'>Název</label>
@@ -37,13 +49,25 @@
       <div class='inputs'><TextareaExpandable placeholder='Popis díla, do seznamu tvorby a novinek' {user} id='workAnnotation' name='workAnnotation' minHeight={80} maxlength={150} /></div>
     </div>
 
-    <div class='row'>
-      <div class='labels'>Obsah</div>
-      <div class='inputs'>
-        <TextareaExpandable {user} bind:this={editorRef} allowHtml minHeight={500} />
-        <input type='hidden' name='workContent' bind:this={contentInputRef} />
+    {#if type === 'text'}
+      <div class='row'>
+        <div class='labels'>Obsah</div>
+        <div class='inputs'>
+          <TextareaExpandable {user} bind:this={editorRef} allowHtml minHeight={500} />
+          <input type='hidden' name='workContent' bind:this={contentInputRef} />
+        </div>
       </div>
-    </div>
+    {:else}
+      <div class='row'>
+        <div class='labels'><label for='workFile'>Soubor</label></div>
+        <div class='inputs'>
+          <input type='file' bind:this={fileInputRef} bind:files on:change={showPreview} id='workFile' name='workFile' accept={type === 'image' ? 'image/*' : 'audio/*'} />
+        </div>
+      </div>
+      {#if previewUrl && type === 'image'}
+        <div class='row'><img src={previewUrl} alt='preview' class='preview'/></div>
+      {/if}
+    {/if}
 
     <div class='row'>
       <div class='labels'>
@@ -67,6 +91,7 @@
         <input type='hidden' name='workTags' bind:this={tagsInputRef} />
       </div>
     </div>
+    <input type='hidden' name='workType' value={type} />
     <center>
       <button type='submit' class='large'>Vytvořit</button>
     </center>
@@ -101,6 +126,9 @@
         }
   center {
     margin-top: 20px;
+  }
+  .preview {
+    max-width: 100%;
   }
   @media (max-width: 860px) {
     .row {

--- a/src/components/works/WorkForm.svelte
+++ b/src/components/works/WorkForm.svelte
@@ -1,5 +1,12 @@
 <script>
-  import { workTags, workCategoriesText } from '@lib/constants'
+  import {
+    workTagsText,
+    workTagsImage,
+    workTagsMusic,
+    workCategoriesText,
+    workCategoriesImage,
+    workCategoriesMusic
+  } from '@lib/constants'
   import Select from 'svelte-select'
   import TextareaExpandable from '@components/common/TextareaExpandable.svelte'
 
@@ -24,7 +31,9 @@
   }
 
   $: maxTags = selectedTags?.length === 3
-  $: tagItems = maxTags ? [] : [...workTags]
+  $: tagSource = type === 'text' ? workTagsText : type === 'image' ? workTagsImage : workTagsMusic
+  $: categoryItems = type === 'text' ? workCategoriesText : type === 'image' ? workCategoriesImage : workCategoriesMusic
+  $: tagItems = maxTags ? [] : [...tagSource]
 
   function showPreview () {
     if (files && files[0]) {
@@ -75,7 +84,7 @@
       </div>
       <div class='inputs'>
         <select id='workCategory' name='workCategory'>
-          {#each workCategoriesText as category}
+          {#each categoryItems as category}
             <option value={category.value}>{category.label}</option>
           {/each}
         </select>

--- a/src/components/works/WorkForm.svelte
+++ b/src/components/works/WorkForm.svelte
@@ -33,7 +33,7 @@
   $: maxTags = selectedTags?.length === 3
   $: tagSource = type === 'text' ? workTagsText : type === 'image' ? workTagsImage : workTagsMusic
   $: categoryItems = type === 'text' ? workCategoriesText : type === 'image' ? workCategoriesImage : workCategoriesMusic
-  $: tagItems = maxTags ? [] : [...tagSource]
+  $: tagItems = maxTags ? [] : tagSource
 
   function showPreview () {
     if (files && files[0]) {

--- a/src/components/works/WorkForm.svelte
+++ b/src/components/works/WorkForm.svelte
@@ -1,4 +1,5 @@
 <script>
+  import { onMount } from 'svelte'
   import {
     workTagsText,
     workTagsImage,
@@ -20,6 +21,21 @@
   let fileInputRef
   let files
   let previewUrl
+  let tagItems = []
+  let categoryItems = []
+
+  onMount(() => {
+    if (type === 'text') {
+      tagItems = [...workTagsText]
+      categoryItems = [...workCategoriesText]
+    } else if (type === 'image') {
+      tagItems = [...workTagsImage]
+      categoryItems = [...workCategoriesImage]
+    } else {
+      tagItems = [...workTagsMusic]
+      categoryItems = [...workCategoriesMusic]
+    }
+  })
 
   const prepareData = async (event) => {
     event.preventDefault()
@@ -31,9 +47,6 @@
   }
 
   $: maxTags = selectedTags?.length === 3
-  $: tagSource = type === 'text' ? workTagsText : type === 'image' ? workTagsImage : workTagsMusic
-  $: categoryItems = type === 'text' ? workCategoriesText : type === 'image' ? workCategoriesImage : workCategoriesMusic
-  $: tagItems = maxTags ? [] : tagSource
 
   function showPreview () {
     if (files && files[0]) {
@@ -78,28 +91,32 @@
       {/if}
     {/if}
 
-    <div class='row'>
-      <div class='labels'>
-        <label for='workCategory'>Kategorie</label>
+    {#if categoryItems.length}
+      <div class='row'>
+        <div class='labels'>
+          <label for='workCategory'>Kategorie</label>
+        </div>
+        <div class='inputs'>
+          <select id='workCategory' name='workCategory'>
+            {#each categoryItems as category}
+              <option value={category.value}>{category.label}</option>
+            {/each}
+          </select>
+        </div>
       </div>
-      <div class='inputs'>
-        <select id='workCategory' name='workCategory'>
-          {#each categoryItems as category}
-            <option value={category.value}>{category.label}</option>
-          {/each}
-        </select>
-      </div>
-    </div>
+    {/if}
 
-    <div class='row'>
-      <div class='labels'><label for='workTags'>Tagy<span class='info'>(max 3)</span></label></div>
-      <div class='inputs'>
-        <Select items={tagItems} multiple bind:value={selectedTags} placeholder=''>
-          <div slot='empty'>Více tagů nelze přidat</div>
-        </Select>
-        <input type='hidden' name='workTags' bind:this={tagsInputRef} />
+    {#if tagItems.length}
+      <div class='row'>
+        <div class='labels'><label for='workTags'>Tagy<span class='info'>(max 3)</span></label></div>
+        <div class='inputs'>
+          <Select items={maxTags ? [] : tagItems} multiple bind:value={selectedTags} placeholder=''>
+            <div slot='empty'>Více tagů nelze přidat</div>
+          </Select>
+          <input type='hidden' name='workTags' bind:this={tagsInputRef} />
+        </div>
       </div>
-    </div>
+    {/if}
     <input type='hidden' name='workType' value={type} />
     <center>
       <button type='submit' class='large'>Vytvořit</button>

--- a/src/components/works/WorkList.svelte
+++ b/src/components/works/WorkList.svelte
@@ -47,6 +47,13 @@
     url.searchParams.set('page', newPage)
     window.location.href = url.toString()
   }
+
+  function navigateTab (tab) {
+    const url = new URL(window.location)
+    url.searchParams.set('tab', tab)
+    url.searchParams.delete('page')
+    window.location.href = url.toString()
+  }
 </script>
 
 {#if showHeadline}
@@ -58,21 +65,21 @@
         <button on:click={() => { setListView(true) }} class:active={listView} class='material'>table_rows_narrow</button>
       </div>
       {#if user.id}
-        <a href='./work/work-form' class='button desktop'>Vytvořit nové dílo</a>
-        <a href='./work/work-form' class='button mobile material'>add</a>
+        <a href={'./work/work-form?type=' + (activeTab === 'articles' ? 'text' : activeTab === 'images' ? 'image' : 'audio')} class='button desktop'>Vytvořit nové dílo</a>
+        <a href={'./work/work-form?type=' + (activeTab === 'articles' ? 'text' : activeTab === 'images' ? 'image' : 'audio')} class='button mobile material'>add</a>
       {/if}
     </div>
   </div>
 {/if}
 
 <nav class='tabs secondary'>
-  <button on:click={() => { activeTab = 'articles' }} class:active={activeTab === 'articles'}>
+  <button on:click={() => { navigateTab('articles') }} class:active={activeTab === 'articles'}>
     Články
   </button>
-  <button disabled on:click={() => { activeTab = 'images' }} class:active={activeTab === 'images'}>
+  <button on:click={() => { navigateTab('images') }} class:active={activeTab === 'images'}>
     Obrázky
   </button>
-  <button disabled on:click={() => { activeTab = 'music' }} class:active={activeTab === 'music'}>
+  <button on:click={() => { navigateTab('music') }} class:active={activeTab === 'music'}>
     Hudba
   </button>
 </nav>

--- a/src/components/works/WorkSettings.svelte
+++ b/src/components/works/WorkSettings.svelte
@@ -32,8 +32,21 @@
   let originalTagsString
   let selectedTagsString
   let headlineEl
+  let tagItems = []
+  let categoryItems = []
 
   onMount(() => {
+    if (data.type === 'text') {
+      tagItems = [...workTagsText]
+      categoryItems = [...workCategoriesText]
+    } else if (data.type === 'image') {
+      tagItems = [...workTagsImage]
+      categoryItems = [...workCategoriesImage]
+    } else {
+      tagItems = [...workTagsMusic]
+      categoryItems = [...workCategoriesMusic]
+    }
+
     normalizeTags()
     setOriginal()
     const observer = new IntersectionObserver(([e]) => e.target.classList.toggle('pinned', e.intersectionRatio < 1), { threshold: [1] })
@@ -70,9 +83,6 @@
 
 
   $: maxTags = data.tags?.length === 3
-  $: tagSource = data.type === 'text' ? workTagsText : data.type === 'image' ? workTagsImage : workTagsMusic
-  $: categoryItems = data.type === 'text' ? workCategoriesText : data.type === 'image' ? workCategoriesImage : workCategoriesMusic
-  $: tagItems = maxTags ? [] : tagSource
   $: selectedTagsString = data.tags?.map(t => t.value).join(',')
 </script>
 
@@ -104,23 +114,27 @@
       <button on:click={updateWork} disabled={saving || originalAnnotation === data.annotation} class='material save square' title='Uložit' use:tooltip>check</button>
     </div>
 
-    <h2>Kategorie</h2>
-    <div class='row'>
-      <select id='workCategory' name='workCategory' bind:value={data.category}>
-        {#each categoryItems as category}
-          <option value={category.value}>{category.label}</option>
-        {/each}
-      </select>
-      <button on:click={updateWork} disabled={saving || originalCategory === data.category} class='material save square' title='Uložit' use:tooltip>check</button>
-    </div>
+    {#if categoryItems.length}
+      <h2>Kategorie</h2>
+      <div class='row'>
+        <select id='workCategory' name='workCategory' bind:value={data.category}>
+          {#each categoryItems as category}
+            <option value={category.value}>{category.label}</option>
+          {/each}
+        </select>
+        <button on:click={updateWork} disabled={saving || originalCategory === data.category} class='material save square' title='Uložit' use:tooltip>check</button>
+      </div>
+    {/if}
 
-    <h2>Tagy</h2>
-    <div class='row'>
-      <Select items={tagItems} multiple bind:value={data.tags} placeholder=''>
-        <div slot='empty'>Více tagů nelze přidat</div>
-      </Select>
-      <button on:click={updateWork} disabled={saving || (selectedTagsString === originalTagsString)} class='material save square' title='Uložit' use:tooltip>check</button>
-    </div>
+    {#if tagItems.length}
+      <h2>Tagy</h2>
+      <div class='row'>
+        <Select items={maxTags ? [] : tagItems} multiple bind:value={data.tags} placeholder=''>
+          <div slot='empty'>Více tagů nelze přidat</div>
+        </Select>
+        <button on:click={updateWork} disabled={saving || (selectedTagsString === originalTagsString)} class='material save square' title='Uložit' use:tooltip>check</button>
+      </div>
+    {/if}
 
     <h2>Smazání díla</h2>
     Pozor, toto je nevratná akce.<br><br>

--- a/src/components/works/WorkSettings.svelte
+++ b/src/components/works/WorkSettings.svelte
@@ -3,17 +3,10 @@
   import { tooltip } from '@lib/tooltip'
   import { showSuccess } from '@lib/toasts'
   import { supabase, handleError } from '@lib/database-browser'
-  import {
-    workTagsText,
-    workTagsImage,
-    workTagsMusic,
-    workCategoriesText,
-    workCategoriesImage,
-    workCategoriesMusic
-  } from '@lib/constants'
+  import { workTagsText, workTagsImage, workTagsMusic, workCategoriesText, workCategoriesImage, workCategoriesMusic } from '@lib/constants'
   import Select from 'svelte-select'
-  import TextareaExpandable from '@components/common/TextareaExpandable.svelte'
   import HeaderInput from '@components/common/HeaderInput.svelte'
+  import TextareaExpandable from '@components/common/TextareaExpandable.svelte'
 
   export let data = {}
   export let user = {}
@@ -80,7 +73,6 @@
   function showWork () {
     window.location.href = `/work/${data.id}`
   }
-
 
   $: maxTags = data.tags?.length === 3
   $: selectedTagsString = data.tags?.map(t => t.value).join(',')

--- a/src/components/works/WorkSettings.svelte
+++ b/src/components/works/WorkSettings.svelte
@@ -72,7 +72,7 @@
   $: maxTags = data.tags?.length === 3
   $: tagSource = data.type === 'text' ? workTagsText : data.type === 'image' ? workTagsImage : workTagsMusic
   $: categoryItems = data.type === 'text' ? workCategoriesText : data.type === 'image' ? workCategoriesImage : workCategoriesMusic
-  $: tagItems = maxTags ? [] : [...tagSource]
+  $: tagItems = maxTags ? [] : tagSource
   $: selectedTagsString = data.tags?.map(t => t.value).join(',')
 </script>
 

--- a/src/components/works/WorkSettings.svelte
+++ b/src/components/works/WorkSettings.svelte
@@ -68,9 +68,6 @@
     window.location.href = `/work/${data.id}`
   }
 
-  $: if (Array.isArray(data.tags) && typeof data.tags[0] === 'string') {
-    normalizeTags()
-  }
 
   $: maxTags = data.tags?.length === 3
   $: tagSource = data.type === 'text' ? workTagsText : data.type === 'image' ? workTagsImage : workTagsMusic

--- a/src/components/works/WorkSettings.svelte
+++ b/src/components/works/WorkSettings.svelte
@@ -3,7 +3,14 @@
   import { tooltip } from '@lib/tooltip'
   import { showSuccess } from '@lib/toasts'
   import { supabase, handleError } from '@lib/database-browser'
-  import { workTags, workCategoriesText } from '@lib/constants'
+  import {
+    workTagsText,
+    workTagsImage,
+    workTagsMusic,
+    workCategoriesText,
+    workCategoriesImage,
+    workCategoriesMusic
+  } from '@lib/constants'
   import Select from 'svelte-select'
   import TextareaExpandable from '@components/common/TextareaExpandable.svelte'
   import HeaderInput from '@components/common/HeaderInput.svelte'
@@ -53,7 +60,9 @@
   }
 
   $: maxTags = data.tags?.length === 3
-  $: tagItems = maxTags ? [] : [...workTags]
+  $: tagSource = data.type === 'text' ? workTagsText : data.type === 'image' ? workTagsImage : workTagsMusic
+  $: categoryItems = data.type === 'text' ? workCategoriesText : data.type === 'image' ? workCategoriesImage : workCategoriesMusic
+  $: tagItems = maxTags ? [] : [...tagSource]
   $: selectedTagsString = data.tags?.map(t => t.value).join(',')
 </script>
 
@@ -88,7 +97,7 @@
     <h2>Kategorie</h2>
     <div class='row'>
       <select id='workCategory' name='workCategory' bind:value={data.category}>
-        {#each workCategoriesText as category}
+        {#each categoryItems as category}
           <option value={category.value}>{category.label}</option>
         {/each}
       </select>

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -54,7 +54,7 @@ create type work_tag as enum (
   'portrait', 'landscape', 'abstract',
   'guitar', 'piano', 'orchestral', 'electronic'
 );
-create type work_category as enum (
+create or replace type work_category as enum (
   'prose', 'poetry', 'game',
   'painting', 'drawing', 'photo', 'digital',
   'instrumental', 'vocal', 'ambient',

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -45,8 +45,21 @@ create type character_state as enum ('alive', 'unconscious', 'dead', 'deleted');
 create type game_system as enum ('base', 'vampire5', 'yearzero', 'dnd5', 'drd1', 'cyberpunk', 'starwars', 'cthulhu', 'warhammer', 'shadowrun', 'pathfinder', 'mutant', 'gurps', 'fate', 'savage', 'dungeonworld', 'onering', 'other');
 create type game_category as enum ('anime', 'cyberpunk', 'detective', 'based', 'fantasy', 'furry', 'history', 'horror', 'comedy', 'scifi', 'steampunk', 'strategy', 'survival', 'urban', 'relationship', 'other');
 create type work_type as enum ('text', 'image', 'audio');
-create type work_tag as enum ('story', 'continued', 'preview', 'thought', 'fanfiction', 'scifi', 'fantasy', 'mythology', 'horror', 'detective', 'romance', 'fairytale', 'dystopia', 'humorous', 'fromlife', 'motivational', 'erotica', 'biography', 'gameworld', 'gamematerial', 'editorial', 'announcement', 'project');
-create type work_category as enum ('prose', 'poetry', 'game', 'other');
+create type work_tag as enum (
+  'story', 'continued', 'preview', 'thought', 'fanfiction', 'scifi', 'fantasy',
+  'mythology', 'horror', 'detective', 'romance', 'fairytale', 'dystopia',
+  'humorous', 'fromlife', 'motivational', 'biography', 'gameworld', 'gamematerial',
+  'editorial', 'announcement', 'project',
+  'erotica',
+  'portrait', 'landscape', 'abstract',
+  'guitar', 'piano', 'orchestral', 'electronic'
+);
+create type work_category as enum (
+  'prose', 'poetry', 'game',
+  'painting', 'drawing', 'photo', 'digital',
+  'instrumental', 'vocal', 'ambient',
+  'other'
+);
 create type post_content_type as enum ('game', 'other');
 
 

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -1536,6 +1536,7 @@ insert into storage.buckets (id, name, public) values ('headers', 'headers', tru
 insert into storage.buckets (id, name, public) values ('portraits', 'portraits', true);
 insert into storage.buckets (id, name, public) values ('posts', 'posts', true);
 insert into storage.buckets (id, name, public) values ('maps', 'maps', true);
+insert into storage.buckets (id, name, public) values ('works', 'works', true);
 
 
 -- SEED  --------------------------------------------

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -45,7 +45,22 @@ export const workCategoriesText = [
   { value: 'other', label: 'Ostatní' }
 ]
 
-export const workTags = [
+export const workCategoriesImage = [
+  { value: 'painting', label: 'Malba' },
+  { value: 'drawing', label: 'Kresba' },
+  { value: 'photo', label: 'Fotografie' },
+  { value: 'digital', label: 'Digitální' },
+  { value: 'other', label: 'Ostatní' }
+]
+
+export const workCategoriesMusic = [
+  { value: 'instrumental', label: 'Instrumentální' },
+  { value: 'vocal', label: 'Zpěv' },
+  { value: 'ambient', label: 'Ambientní' },
+  { value: 'other', label: 'Ostatní' }
+]
+
+export const workTagsText = [
   { value: 'story', label: 'Povídka' },
   { value: 'continued', label: 'Na pokračování' },
   { value: 'preview', label: 'Ukázka' },
@@ -68,4 +83,17 @@ export const workTags = [
   { value: 'editorial', label: 'Editorial' },
   { value: 'announcement', label: 'Oznámení' },
   { value: 'project', label: 'Projekt(íček)' }
+]
+
+export const workTagsImage = [
+  { value: 'portrait', label: 'Portrét' },
+  { value: 'landscape', label: 'Krajina' },
+  { value: 'abstract', label: 'Abstrakce' }
+]
+
+export const workTagsMusic = [
+  { value: 'guitar', label: 'Kytara' },
+  { value: 'piano', label: 'Piano' },
+  { value: 'orchestral', label: 'Orchestrální' },
+  { value: 'electronic', label: 'Elektronická' }
 ]

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -56,7 +56,8 @@ export const workCategoriesImage = [
 export const workCategoriesMusic = [
   { value: 'instrumental', label: 'Instrumentální' },
   { value: 'vocal', label: 'Zpěv' },
-  { value: 'ambient', label: 'Ambientní' },
+  { value: 'orchestral', label: 'Orchestrální' },
+  { value: 'electronic', label: 'Elektronická' },
   { value: 'other', label: 'Ostatní' }
 ]
 
@@ -94,6 +95,20 @@ export const workTagsImage = [
 export const workTagsMusic = [
   { value: 'guitar', label: 'Kytara' },
   { value: 'piano', label: 'Piano' },
-  { value: 'orchestral', label: 'Orchestrální' },
-  { value: 'electronic', label: 'Elektronická' }
+  { value: 'synth', label: 'Syntezátor' },
+  { value: 'drums', label: 'Bicí' },
+  { value: 'bass', label: 'Basová kytara' },
+  { value: 'cello', label: 'Čelo' },
+  { value: 'saxophone', label: 'Saxofon' },
+  { value: 'trumpet', label: 'Trubka' },
+  { value: 'accordion', label: 'Akordeon' },
+  { value: 'harp', label: 'Harfa' },
+  { value: 'clarinet', label: 'Klarinet' },
+  { value: 'trombone', label: 'Trombon' },
+  { value: 'ukulele', label: 'Ukulele' },
+  { value: 'mandolin', label: 'Mandolína' },
+  { value: 'flute', label: 'Flétna' },
+  { value: 'violin', label: 'Housle' },
+  { value: 'remix', label: 'Remix' },
+  { value: 'other', label: 'Ostatní' }
 ]

--- a/src/lib/database-browser.js
+++ b/src/lib/database-browser.js
@@ -28,6 +28,10 @@ export function getPortraitUrl (identityId, hash) {
   return getImageUrl(supabase, path, 'portraits')
 }
 
+export function getWorkFileUrl (path) {
+  return getImageUrl(supabase, path, 'works')
+}
+
 export async function sendPost (method = 'POST', data) {
   if (data.content.trim().length === 0) { return window.showError('Příspěvek nesmí být prázdný') }
   const res = await fetch('/api/post', { method, body: JSON.stringify(data), headers: { 'Content-Type': 'application/json' } })

--- a/src/pages/work/[workId]/index.astro
+++ b/src/pages/work/[workId]/index.astro
@@ -11,8 +11,18 @@
   const { data: workData, error } = await supabase.from('works').select('id, type, name, annotation, content, thread, owner:profiles(id, name), tags, category, custom_header, likes, dislikes, created_at, published').eq('id', workId).single()
   if (error) { return Astro.redirect(`/?toastType=error&toastText=${encodeURIComponent('Chyba: ' + error.message)}`) }
 
-  const { data: unreadData, error: error2 } = await supabase.from('unread_threads').select('unread_count').match({ user_id: user.id, thread_id: workData.thread }).maybeSingle()
-  if (error2) { return Astro.redirect(`/?toastType=error&toastText=${encodeURIComponent('Chyba: ' + error2.message)}`) }
+  let unreadData
+  if (user.id) {
+    const { data, error: error2 } = await supabase
+      .from('unread_threads')
+      .select('unread_count')
+      .match({ user_id: user.id, thread_id: workData.thread })
+      .maybeSingle()
+    if (error2) {
+      return Astro.redirect(`/?toastType=error&toastText=${encodeURIComponent('Chyba: ' + error2.message)}`)
+    }
+    unreadData = data
+  }
   if (unreadData) { workData.unread = unreadData?.unread_count || 0 }
 ---
 

--- a/src/pages/work/work-form.astro
+++ b/src/pages/work/work-form.astro
@@ -3,17 +3,30 @@
   import WorkForm from '@components/works/WorkForm.svelte'
 
   const { supabase, user } = Astro.locals
+  const type = Astro.url.searchParams.get('type') || 'text'
 
   if (Astro.request.method === 'POST') {
     const formData = await Astro.request.formData()
     const name = formData.get('workName')
-    const content = formData.get('workContent')
     const annotation = formData.get('workAnnotation')
     const category = formData.get('workCategory')
     const tags = formData.get('workTags') ? formData.get('workTags').split(',') : []
+    const formType = formData.get('workType') || type
+    let content = formData.get('workContent')
 
-    // 2DO: add 'type' for other types of works
-    const { data, error } = await supabase.from('works').insert({ owner: user.id, name, category, content, annotation, tags }).select().single()
+    if (formType !== 'text') {
+      const file = formData.get('workFile')
+      if (!file || file.size === 0) {
+        return Astro.redirect(`/?toastType=error&toastText=${encodeURIComponent('Chybí soubor')}`)
+      }
+      const fileExt = file.name.split('.').pop()
+      const filePath = `${user.id}/${Date.now()}.${fileExt}`
+      const { error: uploadError } = await supabase.storage.from('works').upload(filePath, file)
+      if (uploadError) { return Astro.redirect(`/?toastType=error&toastText=${encodeURIComponent('Chyba uploadu: ' + uploadError.message)}`) }
+      content = filePath
+    }
+
+    const { data, error } = await supabase.from('works').insert({ owner: user.id, name, category, content, annotation, tags, type: formType }).select().single()
     if (error) { return Astro.redirect(`/?toastType=error&toastText=${encodeURIComponent('Chyba vložení díla: ' + error.message)}`) }
 
     // add bookmark
@@ -35,13 +48,13 @@
     })
     if (postError) { return Astro.redirect(`/?toastType=error&toastText=${encodeURIComponent('Chyba v přidání upozornění na dílo: ' + insertError.message)}`) }
 
-    return Astro.redirect(`/work/${data.id}?toastType=success&toastText=${encodeURIComponent('Článek byl přidán, čeká na schválení')}`)
+    return Astro.redirect(`/work/${data.id}?toastType=success&toastText=${encodeURIComponent('Dílo bylo přidáno, čeká na schválení')}`)
   }
 ---
 
-<Layout title='Vytvořit článek'>
+<Layout title={'Vytvořit ' + (type === 'text' ? 'článek' : type === 'image' ? 'obrázek' : 'hudbu')}>
   <a href='javascript:history.back()'>zpět</a>
 
-  <h1>Vytvořit článek</h1>
-  <WorkForm {user} client:only='svelte' />
+  <h1>Vytvořit {type === 'text' ? 'článek' : type === 'image' ? 'obrázek' : 'hudbu'}</h1>
+  <WorkForm {user} {type} client:only='svelte' />
 </Layout>

--- a/src/pages/works.astro
+++ b/src/pages/works.astro
@@ -8,7 +8,8 @@
   const page = parseInt(Astro.url.searchParams.get('page') || '0')
   const limit = 20
 
-  const { data: works, count, error } = await supabase.from('work_list').select('*', { count: 'exact' }).eq('published', true).range(page * limit, page * limit + limit - 1)
+  const typeMap = { articles: 'text', images: 'image', music: 'audio' }
+  const { data: works, count, error } = await supabase.from('work_list').select('*', { count: 'exact' }).match({ published: true, type: typeMap[activeTab] }).range(page * limit, page * limit + limit - 1)
   const maxPage = Math.ceil(count / limit) - 1
   if (error) { console.error(error) }
 ---


### PR DESCRIPTION
## Summary
- add `works` storage bucket
- generate work file links on client
- allow creating image or audio works
- filter works by type and navigate between tabs
- show uploaded images and audio in works

## Testing
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684af9be3ab0832fb28a160b32a6f620