### PR TITLE
Move SoloGame AI to server

### DIFF
--- a/src/components/solo/SoloGame.svelte
+++ b/src/components/solo/SoloGame.svelte
@@ -4,7 +4,6 @@
   import { onMount } from 'svelte'
   import { tooltip } from '@lib/tooltip'
   import { platform } from '@components/common/MediaQuery.svelte'
-  import { GoogleGenAI } from '@google/genai'
   import TextareaExpandable from '@components/common/TextareaExpandable.svelte'
   import { waitForMediaLoad } from '@lib/utils'
   import { getContextString } from '@lib/solo/gemini'
@@ -13,7 +12,6 @@
 
   const { user = {}, soloGame = {}, soloConcept = {} } = $props()
 
-  let chat
   let inputEl = $state(null)
   let postsEl = $state(null)
   let allPosts = $state([])
@@ -27,7 +25,6 @@
   let distanceFromBottom = $state(0)
   let previousPostsLength = 0
 
-  const ai = new GoogleGenAI({ apiKey: import.meta.env.PUBLIC_GEMINI })
   const displayIncrement = 50
 
   onMount(async () => {
@@ -43,10 +40,8 @@
     if (error) { return handleError(error) }
     allPosts = data
     updateDisplayedPosts()
-    const history = allPosts.map(post => ({ role: post.owner_type === 'user' ? 'user' : 'model', parts: [{ text: post.content }] }))
     const context = getContextString(soloConcept) + '\n\n<h2>Plán hry</h2>' + soloConcept.generated_plan
     storytellerConfig.config.systemInstruction = storytellerInstructions + '\n\n' + context
-    chat = ai.chats.create({ model: 'gemini-2.5-pro', history, config: storytellerConfig.config })
     isLoading = false
   }
 
@@ -61,29 +56,36 @@
     allPosts.push(newPostData)
     displayedPosts.push(newPostData)
 
-    // Send the message to the AI and handle the response
+    // Generate AI response via backend
     isGenerating = true
-    const stream = await chat.sendMessageStream({ message: newPostData.content, config: storytellerConfig.config })
-
     const tempAiPost = { id: `ai-${Date.now()}`, owner_type: 'ai-storyteller', content: '', created_at: new Date().toISOString() }
     allPosts.push(tempAiPost)
     displayedPosts.push(tempAiPost)
     const reactiveAiPost = displayedPosts.at(-1)
 
-    // Process the AI response stream
-    for await (const chunk of stream) {
-      if (chunk.text) {
-        reactiveAiPost.content += chunk.text
-        postsEl.scrollTop = postsEl.scrollHeight // scroll down
-      } else { // Figure out reason for stopping
-        if (chunk.candidates && chunk.candidates[0].finishReason) {
-          console.log('Finish reason:', chunk.candidates[0].finishReason)
-        }
+    try {
+      const res = await fetch('/api/solo/generatePost', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ soloId: soloGame.id, message: newPostData.content })
+      })
+      const reader = res.body.getReader()
+      const decoder = new TextDecoder()
+      while (true) {
+        const { value, done } = await reader.read()
+        if (done) break
+        const text = decoder.decode(value)
+        text.split('\n\n').forEach(line => {
+          const match = line.match(/^data: (.*)$/)
+          if (match) {
+            reactiveAiPost.content += match[1].replace(/\[line-break\]/g, '\n')
+            postsEl.scrollTop = postsEl.scrollHeight
+          }
+        })
       }
+    } catch (err) {
+      handleError(err)
     }
-    // Save the AI-generated post to the database
-    const { error: aiError } = await supabase.from('posts').insert({ thread: soloGame.thread, owner_type: 'ai-storyteller', content: reactiveAiPost.content })
-    if (aiError) { return handleError(aiError) }
     isGenerating = false
   }
 

--- a/src/pages/api/solo/generatePost.js
+++ b/src/pages/api/solo/generatePost.js
@@ -1,0 +1,90 @@
+import { ai } from '@lib/solo/server-gemini'
+import { getContextString, storytellerInstructions, storytellerConfig } from '@lib/solo/gemini'
+
+export const POST = async ({ request, locals }) => {
+  try {
+    const { soloId, message } = await request.json()
+    if (!locals.user?.id) { return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 }) }
+
+    const { data: soloGame, error: gameError } = await locals.supabase.from('solo_games').select('*').eq('id', soloId).single()
+    if (gameError) { return new Response(JSON.stringify({ error: gameError.message }), { status: 500 }) }
+    if (!soloGame || soloGame.player !== locals.user.id) {
+      return new Response(JSON.stringify({ error: 'Access denied' }), { status: 403 })
+    }
+
+    const { data: soloConcept, error: conceptError } = await locals.supabase.from('solo_concepts').select('*').eq('id', soloGame.concept_id).single()
+    if (conceptError) { return new Response(JSON.stringify({ error: conceptError.message }), { status: 500 }) }
+
+    const { data: posts, error: postsError } = await locals.supabase.from('posts').select('*').match({ thread: soloGame.thread }).order('created_at', { ascending: true })
+    if (postsError) { return new Response(JSON.stringify({ error: postsError.message }), { status: 500 }) }
+
+    const history = posts.map(post => ({
+      role: post.owner_type === 'user' ? 'user' : 'model',
+      parts: [{ text: post.content }]
+    }))
+    history.push({ role: 'user', parts: [{ text: message }] })
+
+    const context = getContextString(soloConcept) + '\n\n<h2>Plán hry</h2>' + soloConcept.generated_plan
+    const config = { ...storytellerConfig.config, systemInstruction: storytellerInstructions + '\n\n' + context }
+
+    const chat = ai.chats.create({ model: 'gemini-2.5-pro', history, config })
+    const response = await chat.sendMessageStream({ message, config })
+
+    let finalText = ''
+    let streamController
+    let isClosed = false
+    const vendorStream = new ReadableStream({
+      async start(controller) {
+        streamController = controller
+        const enc = new TextEncoder()
+        try {
+          for await (const chunk of response) {
+            const text = chunk.text
+            if (text) {
+              finalText += text
+              controller.enqueue(enc.encode(`data: ${text.replace(/\n/g, '[line-break]')}\n\n`))
+            }
+          }
+          await locals.supabase.from('posts').insert({ thread: soloGame.thread, owner_type: 'ai-storyteller', content: finalText })
+          isClosed = true
+          controller.close()
+        } catch (error) {
+          isClosed = true
+          if (error.name !== 'AbortError') { throw error }
+        }
+      },
+      cancel() {
+        if (!isClosed && streamController) {
+          try {
+            streamController.close()
+            isClosed = true
+          } catch (error) {
+            console.warn('Controller already closed, ignoring:', error.message)
+          }
+        }
+      }
+    })
+
+    const outStream = new ReadableStream({
+      async start(outController) {
+        const reader = vendorStream.getReader()
+        while (true) {
+          const { value, done } = await reader.read()
+          if (done) break
+          outController.enqueue(value)
+        }
+      }
+    })
+
+    const headers = {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+      'Transfer-Encoding': 'chunked'
+    }
+    return new Response(outStream, { headers })
+  } catch (error) {
+    console.error('Error generating solo post:', error)
+    return new Response(JSON.stringify({ error: error.message }), { status: 500 })
+  }
+}


### PR DESCRIPTION
## Summary
- move AI post generation to new `/api/solo/generatePost` endpoint
- stream Gemini output from backend
- use backend endpoint from SoloGame UI

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685da1c03c00832fb361b654e38337bb