### PR TITLE
Track threads when bookmarks created

### DIFF
--- a/src/components/boards/Board.svelte
+++ b/src/components/boards/Board.svelte
@@ -34,6 +34,8 @@
     const { data: newBookmark, error } = await supabase.from('bookmarks').upsert({ user_id: user.id, board_id: data.id, board_thread: data.thread }, { onConflict: 'user_id, board_id', ignoreDuplicates: true }).select().maybeSingle()
     if (error) { return handleError(error) }
     if (newBookmark) {
+      await supabase.from('read_threads').upsert({ user_id: user.id, thread_id: data.thread }, { onConflict: 'user_id, thread_id', ignoreDuplicates: true })
+      await supabase.from('unread_threads').upsert({ user_id: user.id, thread_id: data.thread, unread_count: 0 }, { onConflict: 'user_id, thread_id', ignoreDuplicates: true })
       $bookmarks.boards = [...$bookmarks.boards, { bookmark_id: newBookmark.id, id: data.id, name: data.name }]
       showSuccess('Záložka přidána')
     }

--- a/src/components/games/Game.svelte
+++ b/src/components/games/Game.svelte
@@ -38,6 +38,8 @@
     const { data: newBookmark, error } = await supabase.from('bookmarks').upsert({ user_id: user.id, game_id: game.id, game_main_thread: game.game_thread, game_discussion_thread: game.discussion_thread }, { onConflict: 'user_id, game_id', ignoreDuplicates: true }).select().maybeSingle()
     if (error) { return handleError(error) }
     if (newBookmark) {
+      await supabase.from('read_threads').upsert([{ user_id: user.id, thread_id: game.game_thread }, { user_id: user.id, thread_id: game.discussion_thread }], { onConflict: 'user_id, thread_id', ignoreDuplicates: true })
+      await supabase.from('unread_threads').upsert([{ user_id: user.id, thread_id: game.game_thread, unread_count: 0 }, { user_id: user.id, thread_id: game.discussion_thread, unread_count: 0 }], { onConflict: 'user_id, thread_id', ignoreDuplicates: true })
       $bookmarks.games = [...$bookmarks.games, { bookmark_id: newBookmark.id, id: game.id, name: game.name }]
       showSuccess('Záložka přidána')
     }

--- a/src/components/games/characters/Character.svelte
+++ b/src/components/games/characters/Character.svelte
@@ -40,6 +40,8 @@
     // add bookmark to the new player
     const { error: bookmarkError } = await supabase.from('bookmarks').upsert({ user_id: character.player.id, game_id: game.id, game_main_thread: game.game_thread, game_discussion_thread: game.discussion_thread }, { onConflict: 'user_id, game_id', ignoreDuplicates: true })
     if (bookmarkError) { return handleError(bookmarkError) }
+    await supabase.from('read_threads').upsert([{ user_id: character.player.id, thread_id: game.game_thread }, { user_id: character.player.id, thread_id: game.discussion_thread }], { onConflict: 'user_id, thread_id', ignoreDuplicates: true })
+    await supabase.from('unread_threads').upsert([{ user_id: character.player.id, thread_id: game.game_thread, unread_count: 0 }, { user_id: character.player.id, thread_id: game.discussion_thread, unread_count: 0 }], { onConflict: 'user_id, thread_id', ignoreDuplicates: true })
 
     // send welcome message to the new player
     if (user.id !== character.player.id) {
@@ -156,6 +158,8 @@
 
       const { error: upsertError } = await supabase.from('bookmarks').upsert({ user_id: user.id, game_id: game.id, game_main_thread: game.game_thread, game_discussion_thread: game.discussion_thread }, { onConflict: 'user_id, game_id', ignoreDuplicates: true })
       if (upsertError) { return handleError(upsertError) }
+      await supabase.from('read_threads').upsert([{ user_id: user.id, thread_id: game.game_thread }, { user_id: user.id, thread_id: game.discussion_thread }], { onConflict: 'user_id, thread_id', ignoreDuplicates: true })
+      await supabase.from('unread_threads').upsert([{ user_id: user.id, thread_id: game.game_thread, unread_count: 0 }, { user_id: user.id, thread_id: game.discussion_thread, unread_count: 0 }], { onConflict: 'user_id, thread_id', ignoreDuplicates: true })
 
       if (user.id !== game.owner.id) {
         const { error: insertError } = await supabase.from('messages').insert({ content: `Převzal/a jsem postavu ${character.name} v tvojí hře ${game.name}`, sender_user: user.id, recipient_user: game.owner.id })

--- a/src/components/works/Work.svelte
+++ b/src/components/works/Work.svelte
@@ -25,6 +25,8 @@
     const { data: newBookmark, error } = await supabase.from('bookmarks').upsert({ user_id: user.id, work_id: data.id, work_thread: data.thread }, { onConflict: 'user_id, work_id', ignoreDuplicates: true }).select().maybeSingle()
     if (error) { return handleError(error) }
     if (newBookmark) {
+      await supabase.from('read_threads').upsert({ user_id: user.id, thread_id: data.thread }, { onConflict: 'user_id, thread_id', ignoreDuplicates: true })
+      await supabase.from('unread_threads').upsert({ user_id: user.id, thread_id: data.thread, unread_count: 0 }, { onConflict: 'user_id, thread_id', ignoreDuplicates: true })
       $bookmarks.works = [...$bookmarks.works, { bookmark_id: newBookmark.id, id: data.id, name: data.name }]
       showSuccess('Záložka přidána')
     }

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -1348,11 +1348,15 @@ $$ language plpgsql;
 create or replace function add_default_bookmarks () returns trigger as $$
 begin
   insert into bookmarks (user_id, board_id, board_thread)
-  select new.id, b.id, b.thread from boards b where b.id = 1;
-  insert into bookmarks (user_id, board_id, board_thread)
-  select new.id, b.id, b.thread from boards b where b.id = 2;
-  insert into bookmarks (user_id, board_id, board_thread)
-  select new.id, b.id, b.thread from boards b where b.id = 3;
+  select new.id, b.id, b.thread from boards b where b.id in (1, 2, 3);
+
+  insert into read_threads (user_id, thread_id)
+  select new.id, b.thread from boards b where b.id in (1, 2, 3)
+  on conflict do nothing;
+
+  insert into unread_threads (user_id, thread_id, unread_count)
+  select new.id, b.thread, 0 from boards b where b.id in (1, 2, 3)
+  on conflict do nothing;
   return new;
 end;
 $$ language plpgsql;

--- a/src/pages/api/solo/createGame.js
+++ b/src/pages/api/solo/createGame.js
@@ -43,6 +43,9 @@ export const GET = async ({ request, locals, redirect }) => {
     const { error: bookmarkError } = await locals.supabase.from('bookmarks').upsert({ user_id: locals.user.id, solo_id: gameData.id }, { onConflict: 'user_id, solo_id', ignoreDuplicates: true })
     if (bookmarkError) { throw new Error('Chyba při přidávání záložky: ' + bookmarkError.message) }
 
+    await locals.supabase.from('read_threads').upsert({ user_id: locals.user.id, thread_id: gameData.thread }, { onConflict: 'user_id, thread_id', ignoreDuplicates: true })
+    await locals.supabase.from('unread_threads').upsert({ user_id: locals.user.id, thread_id: gameData.thread, unread_count: 0 }, { onConflict: 'user_id, thread_id', ignoreDuplicates: true })
+
     // Generate character portrait image
     const { data: portraitImage, error: portraitError } = await generateImage(locals.runtime.env, portraitPrompt, 'npc')
     if (portraitError) { throw new Error('Chyba při generování portrétu postavy: ' + portraitError.message) }

--- a/src/pages/board/board-form.astro
+++ b/src/pages/board/board-form.astro
@@ -20,6 +20,12 @@
     const { error: bookmarkError } = await supabase.from('bookmarks').upsert({ user_id: user.id, board_id: data.id, board_thread: data.thread }, { onConflict: 'user_id, board_id', ignoreDuplicates: true })
     if (bookmarkError) { return Astro.redirect(`/board/board-form?toastType=error&toastText=${encodeURIComponent('Chyba: ' + bookmarkError.message)}`) }
 
+    const { error: readError } = await supabase.from('read_threads').upsert({ user_id: user.id, thread_id: data.thread }, { onConflict: 'user_id, thread_id', ignoreDuplicates: true })
+    if (readError) { return Astro.redirect(`/board/board-form?toastType=error&toastText=${encodeURIComponent('Chyba: ' + readError.message)}`) }
+
+    const { error: unreadError } = await supabase.from('unread_threads').upsert({ user_id: user.id, thread_id: data.thread, unread_count: 0 }, { onConflict: 'user_id, thread_id', ignoreDuplicates: true })
+    if (unreadError) { return Astro.redirect(`/board/board-form?toastType=error&toastText=${encodeURIComponent('Chyba: ' + unreadError.message)}`) }
+
     return Astro.redirect(`/board/${data.id}?toastType=success&toastText=${encodeURIComponent('Diskuze byla přidána')}`)
   }
 ---

--- a/src/pages/game/game-form.astro
+++ b/src/pages/game/game-form.astro
@@ -21,8 +21,20 @@
     if (error) { return Astro.redirect(`/?toastType=error&toastText=${encodeURIComponent('Chyba: ' + error.message)}`) }
 
     // add bookmark
-    const { error: bookmarkError } = await supabase.from('bookmarks').upsert({ user_id: user.id, game_id: data.id, game_main_thread: game.game_thread, game_discussion_thread: game.discussion_thread }, { onConflict: 'user_id, game_id', ignoreDuplicates: true })
+    const { error: bookmarkError } = await supabase.from('bookmarks').upsert({ user_id: user.id, game_id: data.id, game_main_thread: data.game_thread, game_discussion_thread: data.discussion_thread }, { onConflict: 'user_id, game_id', ignoreDuplicates: true })
     if (bookmarkError) { return Astro.redirect(`/?toastType=error&toastText=${encodeURIComponent('Chyba: ' + bookmarkError.message)}`) }
+
+    const { error: readErrorMain } = await supabase.from('read_threads').upsert({ user_id: user.id, thread_id: data.game_thread }, { onConflict: 'user_id, thread_id', ignoreDuplicates: true })
+    if (readErrorMain) { return Astro.redirect(`/?toastType=error&toastText=${encodeURIComponent('Chyba: ' + readErrorMain.message)}`) }
+
+    const { error: readErrorDisc } = await supabase.from('read_threads').upsert({ user_id: user.id, thread_id: data.discussion_thread }, { onConflict: 'user_id, thread_id', ignoreDuplicates: true })
+    if (readErrorDisc) { return Astro.redirect(`/?toastType=error&toastText=${encodeURIComponent('Chyba: ' + readErrorDisc.message)}`) }
+
+    const { error: unreadErrorMain } = await supabase.from('unread_threads').upsert({ user_id: user.id, thread_id: data.game_thread, unread_count: 0 }, { onConflict: 'user_id, thread_id', ignoreDuplicates: true })
+    if (unreadErrorMain) { return Astro.redirect(`/?toastType=error&toastText=${encodeURIComponent('Chyba: ' + unreadErrorMain.message)}`) }
+
+    const { error: unreadErrorDisc } = await supabase.from('unread_threads').upsert({ user_id: user.id, thread_id: data.discussion_thread, unread_count: 0 }, { onConflict: 'user_id, thread_id', ignoreDuplicates: true })
+    if (unreadErrorDisc) { return Astro.redirect(`/?toastType=error&toastText=${encodeURIComponent('Chyba: ' + unreadErrorDisc.message)}`) }
 
     return Astro.redirect(`/game/${data.id}?toastType=success&toastText=${encodeURIComponent('Hra byla přidána')}`)
   }

--- a/src/pages/work/work-form.astro
+++ b/src/pages/work/work-form.astro
@@ -33,6 +33,12 @@
     const { error: bookmarkError } = await supabase.from('bookmarks').upsert({ user_id: user.id, work_id: data.id, work_thread: data.thread }, { onConflict: 'user_id, work_id', ignoreDuplicates: true })
     if (bookmarkError) { return Astro.redirect(`/?toastType=error&toastText=${encodeURIComponent('Chyba přidání záložky: ' + bookmarkError.message)}`) }
 
+    const { error: readError } = await supabase.from('read_threads').upsert({ user_id: user.id, thread_id: data.thread }, { onConflict: 'user_id, thread_id', ignoreDuplicates: true })
+    if (readError) { return Astro.redirect(`/?toastType=error&toastText=${encodeURIComponent('Chyba přidání záložky: ' + readError.message)}`) }
+
+    const { error: unreadError } = await supabase.from('unread_threads').upsert({ user_id: user.id, thread_id: data.thread, unread_count: 0 }, { onConflict: 'user_id, thread_id', ignoreDuplicates: true })
+    if (unreadError) { return Astro.redirect(`/?toastType=error&toastText=${encodeURIComponent('Chyba přidání záložky: ' + unreadError.message)}`) }
+
     // get thread of board id 999
     const { data: threadData, error: threadError } = await supabase.from('boards').select('thread').eq('id', 999).single()
     if (threadError) { return Astro.redirect(`/?toastType=error&toastText=${encodeURIComponent('Chyba získání threadu: ' + threadError.message)}`) }


### PR DESCRIPTION
## Summary
- extend `add_default_bookmarks` trigger to seed read/unread counters
- ensure bookmark upserts also create entries in `read_threads` and `unread_threads`

## Testing
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6880eba3c4c8832faffc4b72ab5b0da9