### PR TITLE
Add abilities to solo games

### DIFF
--- a/src/components/solo/CharacterPanel.svelte
+++ b/src/components/solo/CharacterPanel.svelte
@@ -2,7 +2,7 @@
   import { fly } from 'svelte/transition'
   import { onMount, onDestroy } from 'svelte'
 
-  let { game = {}, isOpen = $bindable(false) } = $props()
+  let { game = {}, concept = {}, isOpen = $bindable(false) } = $props()
 
   let panelEl = $state()
   let isFullyOpen = $state(false)
@@ -19,12 +19,24 @@
   <div class='overlay'></div>
   <aside class='panel' bind:this={panelEl} transition:fly={{ x: 300, duration: 150 }} onintroend={() => { isFullyOpen = true }} onoutroend={() => { isFullyOpen = false }}>
     <button onclick={() => { isOpen = false }} class='close'><span class='material'>close</span></button>
-    <h2>Inventář</h2>
-    <ul>
-      {#each game.inventory as item, i (i)}
-        <li>{item}</li>
-      {/each}
-    </ul>
+    <div class='lists'>
+      <div>
+        <h2>Inventář</h2>
+        <ul>
+          {#each game.inventory as item, i (i)}
+            <li>{item}</li>
+          {/each}
+        </ul>
+      </div>
+      <div>
+        <h2>Schopnosti</h2>
+        <ul>
+          {#each concept.abilities as ab, i (i)}
+            <li>{ab}</li>
+          {/each}
+        </ul>
+      </div>
+    </div>
   </aside>
 {/if}
 
@@ -79,6 +91,12 @@
       border-radius: 5px;
       background: var(--block);
     }
+
+  .lists {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 20px;
+  }
 
   @media (max-width: 768px) {
     .panel {

--- a/src/components/solo/Concept.svelte
+++ b/src/components/solo/Concept.svelte
@@ -134,14 +134,14 @@
     try {
       // Reset the generating array in the database
       const { error: resetError } = await supabase.from('solo_concepts').update({
-        generating: ['annotation', 'generated_world', 'generated_factions', 'generated_locations', 'generated_characters', 'generated_protagonist', 'generated_header_image', 'generated_storyteller_image', 'generated_plan', 'protagonist_names', 'inventory', 'header_image', 'storyteller_image'],
+        generating: ['annotation', 'generated_world', 'generated_factions', 'generated_locations', 'generated_characters', 'generated_protagonist', 'generated_header_image', 'generated_storyteller_image', 'generated_plan', 'protagonist_names', 'inventory', 'abilities', 'header_image', 'storyteller_image'],
         generation_error: ''
       }).eq('id', concept.id)
 
       if (resetError) { throw new Error(resetError.message) }
 
       // Update local state
-      concept.generating = ['annotation', 'generated_world', 'generated_factions', 'generated_locations', 'generated_characters', 'generated_protagonist', 'generated_header_image', 'generated_storyteller_image', 'generated_plan', 'protagonist_names', 'inventory', 'header_image', 'storyteller_image']
+      concept.generating = ['annotation', 'generated_world', 'generated_factions', 'generated_locations', 'generated_characters', 'generated_protagonist', 'generated_header_image', 'generated_storyteller_image', 'generated_plan', 'protagonist_names', 'inventory', 'abilities', 'header_image', 'storyteller_image']
       concept.generation_error = ''
       concept = { ...concept } // Trigger reactivity
 
@@ -178,6 +178,7 @@
         <li><span class='material'>{concept.generating.includes('storyteller_image') ? 'hourglass_top' : 'check'}</span><span class='wide'>Obrázek vypravěče</span></li>
         <li><span class='material'>{concept.generating.includes('protagonist_names') ? 'hourglass_top' : 'check'}</span><span class='wide'>Jména pro postavu</span></li>
         <li><span class='material'>{concept.generating.includes('inventory') ? 'hourglass_top' : 'check'}</span><span class='wide'>Inventář</span></li>
+        <li><span class='material'>{concept.generating.includes('abilities') ? 'hourglass_top' : 'check'}</span><span class='wide'>Schopnosti</span></li>
         <li><span class='material'>{concept.generating.includes('generated_plan') ? 'hourglass_top' : 'check'}</span><span class='wide'>Příběh</span></li>
       </ul>
     </div>
@@ -217,12 +218,24 @@
         <summary>Postava</summary>
         <div class='inner'>
           <p>{@html concept.generated_protagonist}</p>
-          <h3>Inventář</h3>
-          <ul class='inventory grid'>
-            {#each concept.inventory as item, i (i)}
-              <li>{item}</li>
-            {/each}
-          </ul>
+          <div class='character-lists'>
+            <div>
+              <h3>Inventář</h3>
+              <ul class='inventory grid'>
+                {#each concept.inventory as item, i (i)}
+                  <li>{item}</li>
+                {/each}
+              </ul>
+            </div>
+            <div>
+              <h3>Schopnosti</h3>
+              <ul class='abilities grid'>
+                {#each concept.abilities as abil, i (i)}
+                  <li>{abil}</li>
+                {/each}
+              </ul>
+            </div>
+          </div>
         </div>
       </details>
       {#if openGames.length > 0}
@@ -417,13 +430,14 @@
         box-shadow: var(--shadow);
         padding: 15px;
       }
-    .inventory {
+    .character-lists {
       display: grid;
       grid-template-columns: repeat(2, 1fr);
+      gap: 20px;
     }
-      .inventory li {
-        margin-bottom: 10px;
-      }
+    .inventory li, .abilities li {
+      margin-bottom: 10px;
+    }
 
   @media (max-width: 500px) {
     .headline {

--- a/src/components/solo/ConceptSettings.svelte
+++ b/src/components/solo/ConceptSettings.svelte
@@ -94,6 +94,23 @@
     savingValues.inventory = false
   }
 
+  async function regenerateAbilities () {
+    savingValues.abilities = true
+    const response = await fetch('/api/solo/generateField', { method: 'POST', body: JSON.stringify({ conceptId: concept.id, field: 'abilities' }), headers: { 'Content-Type': 'application/json' } })
+    if (!response.ok) {
+      const { error } = await response.json()
+      savingValues.abilities = false
+      return handleError(new Error(`API error: ${error.message || 'Chyba generování schopností'}`))
+    }
+    const { data, error } = await supabase.from('solo_concepts').select().eq('id', concept.id).single()
+    if (error) {
+      savingValues.abilities = false
+      return handleError(error)
+    }
+    concept.abilities = data.abilities
+    savingValues.abilities = false
+  }
+
   async function saveTags () {
     savingValues.tags = true
     const { error } = await supabase.from('solo_concepts').update({ tags }).eq('id', concept.id)
@@ -194,6 +211,27 @@
         <button onclick={() => { concept.inventory.push('') }} class='add'>Přidat předmět</button>
         <ButtonLoading label='Přegenerovat' handleClick={regenerateItems} loading={savingValues.inventory} class='add' />
         <button onclick={() => onSave('inventory')} disabled={savingValues.inventory || JSON.stringify(originalValues.inventory) === JSON.stringify(concept.inventory)} class='save'>Uložit předměty</button>
+      </center>
+    </div>
+
+    <h2>Schopnosti</h2>
+    <div>
+      <div class='columns'>
+        {#if Array.isArray(concept.abilities)}
+          {#each concept.abilities as ab, index (index)}
+            <div class='name row'>
+              <input type='text' bind:value={concept.abilities[index]} placeholder='Schopnost' />
+              {#if concept.abilities.length > 1}<button onclick={() => { concept.abilities.splice(index, 1) }} class='material delete square' title='Smazat schopnost' use:tooltip>delete</button>{/if}
+            </div>
+          {/each}
+        {:else}
+          <center class='info'>Schopnosti se právě generují...</center>
+        {/if}
+      </div>
+      <center>
+        <button onclick={() => { concept.abilities.push('') }} class='add'>Přidat schopnost</button>
+        <ButtonLoading label='Přegenerovat' handleClick={regenerateAbilities} loading={savingValues.abilities} class='add' />
+        <button onclick={() => onSave('abilities')} disabled={savingValues.abilities || JSON.stringify(originalValues.abilities) === JSON.stringify(concept.abilities)} class='save'>Uložit schopnosti</button>
       </center>
     </div>
 

--- a/src/components/solo/SoloGame.svelte
+++ b/src/components/solo/SoloGame.svelte
@@ -10,7 +10,7 @@
   import Post from '@components/common/Post.svelte'
   import ImagePost from '@components/common/ImagePost.svelte'
   import WorldPanel from '@components/solo/WorldPanel.svelte'
-  import InventoryPanel from '@components/solo/InventoryPanel.svelte'
+  import CharacterPanel from '@components/solo/CharacterPanel.svelte'
   import TextareaExpandable from '@components/common/TextareaExpandable.svelte'
 
   const { user = {}, game = {}, character = {}, concept = {}, readonly } = $props()
@@ -25,7 +25,7 @@
   let hasMorePosts = $state(true)
   let displayedPosts = $state([])
   let displayedCount = $state(50)
-  let isInventoryOpen = $state(false)
+  let isCharacterOpen = $state(false)
   let userHasScrolledUp = $state(false)
   let distanceFromBottom = $state(0)
   let previousPostsLength = 0
@@ -250,12 +250,12 @@
 
 <main>
   <WorldPanel {concept} bind:isOpen={isWorldOpen} />
-  <InventoryPanel {game} bind:isOpen={isInventoryOpen} />
+  <CharacterPanel {game} {concept} bind:isOpen={isCharacterOpen} />
   <div class='headline'>
     <a href='/solo/concept/{concept.id}'><h1>{game.name}</h1></a>
     <div class='buttons'>
       <div class='limit' title='Denní limit počtu odpovědí od AI vypravěče' use:tooltip>{user.solo_limit}</div>
-      <button onclick={() => { isInventoryOpen = true }} class='material square' title='Inventář' use:tooltip>backpack</button>
+      <button onclick={() => { isCharacterOpen = true }} class='material square' title='Postava' use:tooltip>backpack</button>
       <button onclick={() => { isWorldOpen = true }} class='material square' title='Svět' use:tooltip>globe</button>
       {#if user.id}
         <button onclick={showSettings} class='material settings square' title='Nastavení hry' use:tooltip>settings</button>

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -139,6 +139,7 @@ create table solo_concepts (
   generated_header_image text,
   generated_storyteller_image text,
   inventory text[] not null default '{}'::text[],
+  abilities text[] not null default '{}'::text[],
   tags public.game_tag[] default '{}'::public.game_tag[],
   game_count int4 default 0,
   upvotes int4 default 0,

--- a/src/lib/solo/solo.js
+++ b/src/lib/solo/solo.js
@@ -30,6 +30,7 @@ export const getPrompts = (concept) => {
     prompt_storyteller_image: `Napiš plaintext: AI prompt k vygenerování portrétu pro NPC vypravěče této TTRPG hry. Obrázek by měl být ve stejném stylu jako hlavní obrázek hry a měl by být portrétem tajemné siluety, někoho, kdo by mohl být skrytou božskou bytostí v tomto světě. Duch, prázdný plášť, létající světlo, mrak, digitální bytost jako z Matrixu atd. Cokoliv, co se hodí k tématu hry. Výstup musí být prostý text, v angličtině, bez HTML, jeden odstavec, maximální délka 480 tokenů. ${artStyleAffix} ${imageSafetyAffix}\n`,
     protagonist_names: 'Napiš plaintext: 10 různorodých jmen pro postavu, kterou bude hráč hrát. Čtyři jména jasně mužská, čtyři jasně ženská, dvě neutrální. Jména by měla by ladit s atmosférou světa. Použij buď jazyky daného světa, nebo stylová jména česká. Jména by měla být většinou včetně příjmení, s přezdívkou, výjimečně jen jedno jméno samotné.\n',
     inventory: 'Napiš plaintext: Seznam vybavení hlavní postavy (jasný a definitivní, žádné "nebo") - co by měla postava nést s sebou na začátku hry. Seznam by měl obsahovat 5-15 položek, které sedí k původu či povolání postavy, zásadní pro její přežití, nebo jsou podstatné pro příběh. Zohledni přinejmenším tyto možnosti: platidla, oblečení, výzbroj (zbroje, zbraně, munice etc), cestovní vybavení (voda, jídlo, léky etc), dopravní prostředky, zvířata, osobní předměty, questové předměty. \n',
+    abilities: 'Napiš plaintext: Seznam 5-10 schopností nebo dovedností hlavní postavy, které vychází z jejího popisu a minulosti. Každou schopnost popiš jedním krátkým výrazem. \n',
     annotation: 'Napiš plaintext: Jeden odstavec poutavého reklamního textu, který naláká hráče k zahrání této hry. Zaměř se na atmosféru a hlavní témata příběhu. Výstup musí být plaintext, bez HTML a CSS stylů.\n',
     first_image: `Napiš plaintext: AI prompt k vygenerování ilustračního obrázku pro první scénu této hry. Obrázek by měl zachytit podstatu první scény, ukazovat její charakteristické rysy a atmosféru. Napiš podrobný popis scény a zejména velmi podobně herní postavy a předměty. Výstup musí být prostý text, v angličtině, bez HTML. ${imageSafetyAffix} ${illustrationStyleAffix}\n`,
     protagonist_image: `Napiš plaintext: AI prompt k vygenerování portrétu hráčské postavy v TTRPG hře. Napiš podrobný popis vzhledu, obrázek by měl zachytit podstatu postavy, ukazovat její charakteristické rysy a oděv. Výstup musí být prostý text, v angličtině, bez HTML. ${imageSafetyAffix} ${artStyleAffix}\n`,
@@ -99,10 +100,10 @@ export const imageSizes = {
   npc: { width: 200, height: 400 }
 }
 
-export const fieldNames = { prompt_world: 'Svět', prompt_factions: 'Frakce', prompt_locations: 'Lokace', prompt_characters: 'Postavy', prompt_protagonist: 'Postava hráče', prompt_plan: 'Plán hry', prompt_header_image: 'Ilustrační obrázek', prompt_storyteller_image: 'Portrét vypravěče', protagonist_names: 'Jména postavy', annotation: 'Reklamní text', first_image: 'Obrázek první scény', protagonist_image: 'Portrét postavy', inventory: 'Inventář postavy' }
+export const fieldNames = { prompt_world: 'Svět', prompt_factions: 'Frakce', prompt_locations: 'Lokace', prompt_characters: 'Postavy', prompt_protagonist: 'Postava hráče', prompt_plan: 'Plán hry', prompt_header_image: 'Ilustrační obrázek', prompt_storyteller_image: 'Portrét vypravěče', protagonist_names: 'Jména postavy', annotation: 'Reklamní text', first_image: 'Obrázek první scény', protagonist_image: 'Portrét postavy', inventory: 'Inventář postavy', abilities: 'Schopnosti postavy' }
 
 // Function to provide full context for the AI model, in array of messages. It excludes the specific part that is being generated
-export function getContext (conceptData, exclude, characterName, inventory) {
+export function getContext (conceptData, exclude, characterName, inventory, abilities) {
   const context = {
     basePrompt: { text: `Hra se bude jmenovat "${decodeURIComponent(conceptData.name)}". Budou následovat podklady (setting) pro tuto hru.` },
     prompt_world: { text: `<h2>${fieldNames.prompt_world}</h2>\n${conceptData.generated_world}` },
@@ -113,6 +114,7 @@ export function getContext (conceptData, exclude, characterName, inventory) {
   }
   if (characterName) { context.prompt_protagonist.text += `\nJméno postavy: ${characterName}\n` }
   if (isFilledArray(inventory)) { context.prompt_protagonist.text += `\nInventář: ${inventory.join(', ')}\n` }
+  if (isFilledArray(abilities)) { context.prompt_protagonist.text += `\nSchopnosti: ${abilities.join(', ')}\n` }
   if (exclude) { delete context[exclude] }
   return Object.values(context).map(item => item.text).join('\n\n')
 }

--- a/src/pages/api/solo/createGame.js
+++ b/src/pages/api/solo/createGame.js
@@ -18,7 +18,7 @@ export const GET = async ({ request, locals, redirect }) => {
     const { data: concept, error: conceptError } = await locals.supabase.from('solo_concepts').select('*').eq('id', conceptId).single()
     if (conceptError) { throw new Error('Chyba při načítání konceptu: ' + conceptError.message) }
     if (!concept) { throw new Error('Koncept nebyl nalezen') }
-    const context = getContext(concept, null, characterName, concept.inventory)
+    const context = getContext(concept, null, characterName, concept.inventory, concept.abilities)
     const prompts = getPrompts(concept)
 
     // Increment the concept's play count

--- a/src/pages/api/solo/generatePost.js
+++ b/src/pages/api/solo/generatePost.js
@@ -67,12 +67,15 @@ export const POST = async ({ request, locals }) => {
 
       // Prepare post history for the AI model
       const history = posts.map(post => ({ role: post.owner_type === 'user' ? 'user' : 'model', parts: [{ text: post.content }] }))
-      // Add a system message to the history with current inventory for the model's context
+      // Add a system message to the history with current inventory and abilities for the model's context
       if (gameData.inventory && gameData.inventory.length > 0) {
         history.push({ role: 'model', parts: [{ text: `[System Information: The player's current inventory contains: ${gameData.inventory.join(', ')}]` }] })
       }
+      if (conceptData.abilities && conceptData.abilities.length > 0) {
+        history.push({ role: 'model', parts: [{ text: `[System Information: The player's abilities are: ${conceptData.abilities.join(', ')}]` }] })
+      }
       storytellerParams.config.systemInstruction = `${storytellerInstructions}
-        ${getContext(conceptData, null, characterName, gameData.inventory)}
+        ${getContext(conceptData, null, characterName, gameData.inventory, conceptData.abilities)}
         <h2>Plán hry:</h2>
         ${conceptData.generated_plan}
       `

--- a/src/pages/solo/concept/concept-form.astro
+++ b/src/pages/solo/concept/concept-form.astro
@@ -15,7 +15,7 @@
       // Create the concept record
       const { data: conceptData, error } = await supabase.from('solo_concepts').insert({
         author: user.id, name, prompt_world: world, prompt_plan: plan, prompt_protagonist: protagonist, prompt_locations: locations, prompt_factions: factions, prompt_characters: characters, prompt_header_image: promptHeaderImage, prompt_storyteller_image: promptStorytellerImage, tags, illustration_style: illustrationStyle,
-        generating: ['annotation', 'generated_world', 'generated_factions', 'generated_locations', 'generated_characters', 'generated_protagonist', 'generated_header_image', 'generated_storyteller_image', 'generated_plan', 'protagonist_names', 'inventory', 'header_image', 'storyteller_image']
+        generating: ['annotation', 'generated_world', 'generated_factions', 'generated_locations', 'generated_characters', 'generated_protagonist', 'generated_header_image', 'generated_storyteller_image', 'generated_plan', 'protagonist_names', 'inventory', 'abilities', 'header_image', 'storyteller_image']
       }).select().single()
 
       if (error) { throw new Error('Error creating concept: ' + error.message) }


### PR DESCRIPTION
## Summary
- extend schema for abilities
- generate & edit abilities for solo concepts
- display abilities alongside inventory
- include abilities in post generation context
- rework inventory panel into character panel

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6881ec427334832fbf1122f52e8d2096