### PR TITLE
Fix editor clearing on failed submit

### DIFF
--- a/src/components/Discussion.svelte
+++ b/src/components/Discussion.svelte
@@ -88,7 +88,7 @@
   }
 
   async function submitPost () {
-    if (saving || textareaValue === '') { return }
+    if (saving || textareaValue === '') { return false }
     saving = true
     const identity = useIdentities ? getIdentity() : userIdentity
     let audience = null
@@ -107,9 +107,12 @@
       textareaValue = ''
       $discussionStore.unsent = ''
       await loadPosts()
-      saving = false
       editing = false
+      saving = false
+      return true
     }
+    saving = false
+    return false
   }
 
   async function deletePost (post) {

--- a/src/components/chat/Chat.svelte
+++ b/src/components/chat/Chat.svelte
@@ -198,7 +198,7 @@
   }
 
   async function submitPost () {
-    if (saving || textareaValue === '') { return }
+    if (saving || textareaValue === '') { return false }
     saving = true
     let response
     if (editing) {
@@ -209,9 +209,12 @@
     if (!response.error) {
       textareaValue = ''
       await loadPosts()
-      saving = false
       editing = false
+      saving = false
+      return true
     }
+    saving = false
+    return false
   }
 
   function removeTyping (name) {

--- a/src/components/common/TextareaExpandable.svelte
+++ b/src/components/common/TextareaExpandable.svelte
@@ -96,10 +96,14 @@
     saving = true
     if (allowHtml) {
       value = await tiptap.getHTML() // get latest html from editor
-      await onSave()
-      tiptap.commands.clearContent(true)
+      const result = await onSave()
+      if (!result?.error && result !== false) {
+        tiptap.commands.clearContent(true)
+        value = ''
+      }
     } else {
-      await onSave() // otherwise the binded textarea value is used
+      const result = await onSave() // otherwise the binded textarea value is used
+      if (!result?.error && result !== false) { value = '' }
     }
     saving = false
   }

--- a/src/components/games/GameThread.svelte
+++ b/src/components/games/GameThread.svelte
@@ -97,7 +97,7 @@
   }
 
   async function submitPost () {
-    if (saving || textareaValue === '') { return }
+    if (saving || textareaValue === '') { return false }
     saving = true
     let response
     const audience = activeAudienceIds.includes('*') ? null : activeAudienceIds // clean '*' from audience
@@ -111,9 +111,12 @@
       textareaValue = ''
       $gameStore.unsent = ''
       await loadPosts()
-      saving = false
       editing = false
+      saving = false
+      return true
     }
+    saving = false
+    return false
   }
 
   async function deletePost (post) {


### PR DESCRIPTION
## Summary
- prevent input clearing in `TextareaExpandable` when onSave fails
- make Chat, Discussion, and GameThread submit handlers return success and reset state correctly

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6889dfd78b3c832fb175604fb22cd91d