### PR TITLE
feat: show random npc post on homepage

### DIFF
--- a/src/components/homepage/NewsItem.svelte
+++ b/src/components/homepage/NewsItem.svelte
@@ -41,11 +41,11 @@
       <h4 class='subheadline'>{subHeadline[item.content_type] || item.subheadline}</h4>
     {/if}
     {#if item.url}
-      <a href={item.url}><h3 class='headline'>Ukázka z <em>{item.title}</em></h3></a>
+      <a href={item.url}><h3 class='headline'>Ukázka ze hry <em>{item.title}</em></h3></a>
     {:else if item.content_id}
-      <a href={path[item.content_type] + item.content_id}><h3 class='headline'>Ukázka z <em>{item.title}</em></h3></a>
+      <a href={path[item.content_type] + item.content_id}><h3 class='headline'>Ukázka ze hry <em>{item.title}</em></h3></a>
     {:else}
-      <h3 class='headline'>Ukázka z <em>{item.title}</em></h3>
+      <h3 class='headline'>Ukázka ze hry <em>{item.title}</em></h3>
     {/if}
     <div class={'post ' + $platform}>
       {#if $platform === 'desktop'}

--- a/src/components/homepage/NewsItem.svelte
+++ b/src/components/homepage/NewsItem.svelte
@@ -40,12 +40,12 @@
     {#if subHeadline[item.content_type] || item.subheadline}
       <h4 class='subheadline'>{subHeadline[item.content_type] || item.subheadline}</h4>
     {/if}
-    {#if item.content_type === 'post' && item.url}
-      <a href={item.url}><h2 class='headline'>{item.title}</h2></a>
+    {#if item.url}
+      <a href={item.url}><h3 class='headline'>Ukázka z <em>{item.title}</em></h3></a>
     {:else if item.content_id}
-      <a href={path[item.content_type] + item.content_id}><h2 class='headline'>{item.title}</h2></a>
+      <a href={path[item.content_type] + item.content_id}><h3 class='headline'>Ukázka z <em>{item.title}</em></h3></a>
     {:else}
-      <h2 class='headline'>{item.title}</h2>
+      <h3 class='headline'>Ukázka z <em>{item.title}</em></h3>
     {/if}
     <div class={'post ' + $platform}>
       {#if $platform === 'desktop'}

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -21,6 +21,7 @@ drop type if exists post_content_type;
 drop view if exists posts_owner;
 drop view if exists discussion_posts_owner;
 drop view if exists game_posts_owner;
+drop view if exists npc_posts_random;
 drop view if exists board_list;
 drop view if exists game_list;
 drop view if exists work_list;
@@ -507,8 +508,16 @@ create or replace view posts_owner as
     left join profiles on p.owner = profiles.id and p.owner_type = 'user'
     left join characters on p.owner = characters.id and p.owner_type = 'character'
     left join reactions on p.id = reactions.item_id and reactions.item_type = 'post'
-    left join npcs on p.owner = npcs.id and p.owner_type = 'npc'
+  left join npcs on p.owner = npcs.id and p.owner_type = 'npc'
   order by p.created_at desc;
+
+
+create or replace view npc_posts_random as
+  select
+    *
+  from posts_owner
+  where owner_type = 'npc'
+  order by random();
 
 
 create or replace view game_posts_owner as

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -514,9 +514,11 @@ create or replace view posts_owner as
 
 create or replace view npc_posts_random as
   select
-    *
-  from posts_owner
-  where owner_type = 'npc'
+    po.*, sc.id as concept_id, sc.name as concept_name
+  from posts_owner po
+    join npcs on po.owner = npcs.id
+    left join solo_concepts sc on npcs.solo_concept = sc.id
+  where po.owner_type = 'npc'
   order by random();
 
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -30,13 +30,11 @@
         }
 
         try {
-                const { data: randomPost, error: randomError } = await supabase
-                        .from('posts_owner')
-                        .select('id, content, owner, owner_name, created_at')
-                        .eq('owner_type', 'npc')
-                        .order('random')
-                        .limit(1)
-                        .maybeSingle()
+               const { data: randomPost, error: randomError } = await supabase
+                       .from('npc_posts_random')
+                       .select('id, content, owner, owner_name, created_at')
+                       .limit(1)
+                       .maybeSingle()
                 if (randomError) { throw randomError }
                 if (randomPost) {
                         npcPost = {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,10 +1,11 @@
 ---
-	import Layout from '@layouts/layout.astro'
-	import Editorial from '@components/homepage/Editorial.svelte'
-	import Latest from '@components/homepage/Latest.svelte'
-	import NewsFeed from '@components/homepage/NewsFeed.svelte'
+        import Layout from '@layouts/layout.astro'
+        import Editorial from '@components/homepage/Editorial.svelte'
+        import Latest from '@components/homepage/Latest.svelte'
+        import NewsFeed from '@components/homepage/NewsFeed.svelte'
+        import NewsItem from '@components/homepage/NewsItem.svelte'
 
-	let newsError, lastEditorial, news, maxPage
+        let newsError, lastEditorial, news, maxPage, npcPost
 	const { supabase, user } = Astro.locals
 	const params = Object.fromEntries(Astro.url.searchParams)
 
@@ -16,17 +17,42 @@
 		newsError = 'Chyba načtení editorialu: ' + error.message
 	}
 
-	const publishedOnly = params.preview ? false : true // preview unpublished news
-	const page = params.page ? parseInt(params.page) : 0
-	const limit = 5
-	try {
-		const res2 = await supabase.from('news_reactions').select('*', { count: 'exact' }).eq('published', publishedOnly).order('created_at', { ascending: false }).range(page * limit, page * limit + limit - 1)
-		if (res2.error) { throw res2.error }
-		news = res2.data
-		maxPage = Math.ceil(res2.count / limit) - 1
-	} catch (error) {
-		newsError = 'Chyba načtení novinek: ' + error.message
-	}
+        const publishedOnly = params.preview ? false : true // preview unpublished news
+        const page = params.page ? parseInt(params.page) : 0
+        const limit = 5
+        try {
+                const res2 = await supabase.from('news_reactions').select('*', { count: 'exact' }).eq('published', publishedOnly).order('created_at', { ascending: false }).range(page * limit, page * limit + limit - 1)
+                if (res2.error) { throw res2.error }
+                news = res2.data
+                maxPage = Math.ceil(res2.count / limit) - 1
+        } catch (error) {
+                newsError = 'Chyba načtení novinek: ' + error.message
+        }
+
+        try {
+                const { data: randomPost, error: randomError } = await supabase
+                        .from('posts_owner')
+                        .select('id, content, owner, owner_name, created_at')
+                        .eq('owner_type', 'npc')
+                        .order('random')
+                        .limit(1)
+                        .maybeSingle()
+                if (randomError) { throw randomError }
+                if (randomPost) {
+                        npcPost = {
+                                id: randomPost.id,
+                                content_type: 'post',
+                                title: 'Náhodný příspěvek',
+                                content: randomPost.content,
+                                character: randomPost.owner,
+                                character_name: randomPost.owner_name,
+                                created_at: randomPost.created_at,
+                                owner_id: user?.id
+                        }
+                }
+        } catch (error) {
+                newsError = 'Chyba načtení příspěvku: ' + error.message
+        }
 ---
 
 <Layout title='Hlavní strana'>
@@ -35,10 +61,11 @@
 		<aside>
 			<Latest client:only='svelte' />
 		</aside>
-		<content>
-			<NewsFeed {user} {news} {page} {maxPage} client:only='svelte' />
-		</content>
-	</main>
+                <content>
+                        {npcPost ? <NewsItem {user} item={npcPost} client:only='svelte' /> : null}
+                        <NewsFeed {user} {news} {page} {maxPage} client:only='svelte' />
+                </content>
+        </main>
 </Layout>
 
 <style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -32,7 +32,7 @@
         try {
                const { data: randomPost, error: randomError } = await supabase
                        .from('npc_posts_random')
-                       .select('id, content, owner, owner_name, created_at')
+                       .select('id, content, owner, owner_name, created_at, concept_id, concept_name')
                        .limit(1)
                        .maybeSingle()
                 if (randomError) { throw randomError }
@@ -40,7 +40,8 @@
                         npcPost = {
                                 id: randomPost.id,
                                 content_type: 'post',
-                                title: 'Náhodný příspěvek',
+                                title: randomPost.concept_name,
+                                url: `/solo/concept/${randomPost.concept_id}`,
                                 content: randomPost.content,
                                 character: randomPost.owner,
                                 character_name: randomPost.owner_name,

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,11 +1,11 @@
 ---
-        import Layout from '@layouts/layout.astro'
-        import Editorial from '@components/homepage/Editorial.svelte'
-        import Latest from '@components/homepage/Latest.svelte'
-        import NewsFeed from '@components/homepage/NewsFeed.svelte'
-        import NewsItem from '@components/homepage/NewsItem.svelte'
+  import Layout from '@layouts/layout.astro'
+  import Latest from '@components/homepage/Latest.svelte'
+  import NewsFeed from '@components/homepage/NewsFeed.svelte'
+  import NewsItem from '@components/homepage/NewsItem.svelte'
+  import Editorial from '@components/homepage/Editorial.svelte'
 
-        let newsError, lastEditorial, news, maxPage, npcPost
+  let newsError, lastEditorial, news, maxPage, npcPost
 	const { supabase, user } = Astro.locals
 	const params = Object.fromEntries(Astro.url.searchParams)
 
@@ -17,41 +17,27 @@
 		newsError = 'Chyba načtení editorialu: ' + error.message
 	}
 
-        const publishedOnly = params.preview ? false : true // preview unpublished news
-        const page = params.page ? parseInt(params.page) : 0
-        const limit = 5
-        try {
-                const res2 = await supabase.from('news_reactions').select('*', { count: 'exact' }).eq('published', publishedOnly).order('created_at', { ascending: false }).range(page * limit, page * limit + limit - 1)
-                if (res2.error) { throw res2.error }
-                news = res2.data
-                maxPage = Math.ceil(res2.count / limit) - 1
-        } catch (error) {
-                newsError = 'Chyba načtení novinek: ' + error.message
-        }
+  const publishedOnly = params.preview ? false : true // preview unpublished news
+  const page = params.page ? parseInt(params.page) : 0
+  const limit = 5
+  try {
+    const res2 = await supabase.from('news_reactions').select('*', { count: 'exact' }).eq('published', publishedOnly).order('created_at', { ascending: false }).range(page * limit, page * limit + limit - 1)
+    if (res2.error) { throw res2.error }
+    news = res2.data
+    maxPage = Math.ceil(res2.count / limit) - 1
+  } catch (error) {
+    newsError = 'Chyba načtení novinek: ' + error.message
+  }
 
-        try {
-               const { data: randomPost, error: randomError } = await supabase
-                       .from('npc_posts_random')
-                       .select('id, content, owner, owner_name, created_at, concept_id, concept_name')
-                       .limit(1)
-                       .maybeSingle()
-                if (randomError) { throw randomError }
-                if (randomPost) {
-                        npcPost = {
-                                id: randomPost.id,
-                                content_type: 'post',
-                                title: randomPost.concept_name,
-                                url: `/solo/concept/${randomPost.concept_id}`,
-                                content: randomPost.content,
-                                character: randomPost.owner,
-                                character_name: randomPost.owner_name,
-                                created_at: randomPost.created_at,
-                                owner_id: user?.id
-                        }
-                }
-        } catch (error) {
-                newsError = 'Chyba načtení příspěvku: ' + error.message
-        }
+  try {
+    const { data: randomPost, error: randomPostError } = await supabase.from('npc_posts_random').select('id, content, owner, owner_name, created_at, concept_id, concept_name').limit(1).maybeSingle()
+    if (randomPostError) { throw randomPostError }
+    if (randomPost) {
+      npcPost = { id: randomPost.id, content_type: 'post', title: randomPost.concept_name, content: randomPost.content, character: randomPost.owner, character_name: randomPost.owner_name, created_at: randomPost.created_at, owner_id: user?.id }
+    }
+  } catch (error) {
+    newsError = 'Chyba načtení příspěvku: ' + error.message
+  }
 ---
 
 <Layout title='Hlavní strana'>
@@ -60,11 +46,11 @@
 		<aside>
 			<Latest client:only='svelte' />
 		</aside>
-                <content>
-                        {npcPost ? <NewsItem {user} item={npcPost} client:only='svelte' /> : null}
-                        <NewsFeed {user} {news} {page} {maxPage} client:only='svelte' />
-                </content>
-        </main>
+    <content>
+      {npcPost ? <NewsItem {user} item={npcPost} client:only='svelte' /> : null}
+      <NewsFeed {user} {news} {page} {maxPage} client:only='svelte' />
+    </content>
+  </main>
 </Layout>
 
 <style>


### PR DESCRIPTION
## Summary
- display a random NPC-owned post on the front page
- fetch NPC post from `posts_owner` and render via `NewsItem`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a879cdd0b8832f9f8524ff2810baca