### PR TITLE
Disallow email addresses as profile names

### DIFF
--- a/src/components/user/Signup.svelte
+++ b/src/components/user/Signup.svelte
@@ -66,6 +66,7 @@
     if (password.length < 6) { return showError('Heslo musí mít alespoň 6 znaků') }
     if (password !== password2) { return showError('Potvrzení hesla nesouhlasí') }
     if (newLogin.length < 1) { return showError('Login musí mít alespoň 1 znak') }
+    if (/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(newLogin)) { return showError('Login nesmí být e-mailová adresa') }
 
     // Get info about old user
     const hashedPassword = md5(oldPassword).toString()

--- a/src/pages/onboarding.astro
+++ b/src/pages/onboarding.astro
@@ -10,7 +10,11 @@
     const userName = data.get('userName')
     const oldUserName = data.get('oldUserName')
     const oldPassword = data.get('oldPassword')
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
     if (oldPassword && oldUserName) {
+      if (emailRegex.test(oldUserName)) {
+        return Astro.redirect('/?toastType=error&toastText=' + encodeURIComponent('Přezdívka nesmí být e-mailová adresa'))
+      }
       const hashedPassword = md5(oldPassword).toString()
       const { data: userInfoMigrate, error: userError } = await supabase.from('old_users').select('old_id, old_created_at').eq('old_login', oldUserName.toLowerCase()).eq('old_psw', hashedPassword).maybeSingle()
       if (userError) { return Astro.redirect('/?toastType=error&toastText=' + encodeURIComponent('Chyba čtení starých uživatelů: ' + userError.message)) }
@@ -31,7 +35,10 @@
       }
 
     } else {
-      if (userName) {
+    if (userName) {
+      if (emailRegex.test(userName)) {
+        return Astro.redirect('/?toastType=error&toastText=' + encodeURIComponent('Přezdívka nesmí být e-mailová adresa'))
+      }
       // Check availability
       const { data: loginCheck, error: loginError } = await supabase.from('old_users').select('old_login').eq('old_login', userName).maybeSingle()
       if (loginCheck) {


### PR DESCRIPTION
## Summary
- block email addresses during onboarding profile creation
- prevent email-based logins when migrating old accounts

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aae2bbc05c832fbedabcd53ada1767