### PR TITLE
Render header and sidebar on server

### DIFF
--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -1,7 +1,6 @@
 <script>
   import { onMount } from 'svelte'
   import { headerPreview } from '@lib/stores'
-  import { supabase } from '@lib/database-browser'
   import { initToasts, lookForToast } from '@lib/toasts'
 
   const { pathname, headerStatic, headerStorage, showMenu = true, chatUnread = false } = $props()
@@ -9,6 +8,7 @@
   let headerUrl = $state(headerStatic)
   let chatPeople = $state(0)
   let errorFetchingHeader = $state(false)
+  let supabase
 
   async function getHeaderUrl () {
     try {
@@ -20,7 +20,8 @@
     }
   }
 
-  onMount(() => {
+  onMount(async () => {
+    ({ supabase } = await import('@lib/database-browser'))
     $headerPreview = null // clear preview, only used momentarily after upload
     initToasts()
     lookForToast()

--- a/src/components/sidebar/Bookmarks.svelte
+++ b/src/components/sidebar/Bookmarks.svelte
@@ -2,8 +2,10 @@
   import { onMount } from 'svelte'
   import { bookmarks } from '@lib/stores'
   import { isFilledArray } from '@lib/utils'
-  import { supabase, handleError } from '@lib/database-browser'
   import Sortable from 'sortablejs'
+
+  let supabase
+  let handleError
 
   let soloEl = $state()
   let gamesEl = $state()
@@ -19,7 +21,8 @@
   if ($bookmarks.boards) $bookmarks.boards.sort((a, b) => a.index - b.index || a.name.localeCompare(b.name))
   if ($bookmarks.works) $bookmarks.works.sort((a, b) => a.index - b.index || a.name.localeCompare(b.name))
 
-  onMount(() => {
+  onMount(async () => {
+    ({ supabase, handleError } = await import('@lib/database-browser'))
     if (isFilledArray($bookmarks.games)) {
       new Sortable(gamesEl, { animation: 150, handle: '.handle', group: { name: 'games', pull: false }, onStart: sortStart, onEnd: (sort) => sortEnd('games', sort) })
     }

--- a/src/components/sidebar/Characters.svelte
+++ b/src/components/sidebar/Characters.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { getPortraitUrl } from '@lib/database-browser'
+  import { onMount } from 'svelte'
   import { isFilledArray } from '@lib/utils'
   import { tooltip } from '@lib/tooltip'
 
@@ -9,6 +9,15 @@
   // if there are more than 20 characters across all games and stranded, the lists will be collapsed by default
   const listTooLong = isFilledArray(characters.allGrouped) ? (characters.allGrouped.reduce((acc, game) => acc + game.characters.length, 0) + characters.myStranded.length) > 20 : false
   const expandedLists = $state({})
+  let getPortraitUrl
+
+  function portraitUrl (id, hash) {
+    return getPortraitUrl ? getPortraitUrl(id, hash) : ''
+  }
+
+  onMount(async () => {
+    ({ getPortraitUrl } = await import('@lib/database-browser'))
+  })
 
   function openProfile (character) {
     window.location = `${window.location.origin}/game/character?id=${character.id}`
@@ -38,7 +47,7 @@
           {#if character.state !== 'dead' || $userStore.showDead}
             <button onclick={() => { openConversation({ us: selected.character, them: character, type: 'character' }) }}>
               {#if character.portrait}
-                <img src={getPortraitUrl(character.id, character.portrait)} class='portrait' alt={character.name} />
+                <img src={portraitUrl(character.id, character.portrait)} class='portrait' alt={character.name} />
               {:else}
                 <span class='portrait gap'></span>
               {/if}
@@ -73,7 +82,7 @@
                 <li class='mine'>
                   <button onclick={() => { selected = { character, gameIndex, characterIndex } }}>
                     {#if character.portrait}
-                      <img src={getPortraitUrl(character.id, character.portrait)} class='portrait' alt={character.name} />
+                      <img src={portraitUrl(character.id, character.portrait)} class='portrait' alt={character.name} />
                     {:else}
                       <span class='portrait gap'></span>
                     {/if}
@@ -110,7 +119,7 @@
               <li class='mine'>
                 <button onclick={openProfile(character)}>
                   {#if character.portrait}
-                    {#await getPortraitUrl(character.id, character.portrait) then url}<img src={url} class='portrait' alt={character.name} />{/await}
+                    <img src={portraitUrl(character.id, character.portrait)} class='portrait' alt={character.name} />
                   {:else}
                     <span class='portrait gap'></span>
                   {/if}

--- a/src/components/sidebar/Conversation.svelte
+++ b/src/components/sidebar/Conversation.svelte
@@ -3,9 +3,15 @@
   import { waitForMediaLoad } from '@lib/utils'
   import { activeConversation, lightboxImage } from '@lib/stores'
   import { onMount, tick, onDestroy, afterUpdate } from 'svelte'
-  import { supabase, handleError, getPortraitUrl } from '@lib/database-browser'
   import ConversationPost from '@components/sidebar/ConversationPost.svelte'
   import TextareaExpandable from '@components/common/TextareaExpandable.svelte'
+
+  let supabase
+  let handleError
+  let getPortraitUrl
+  function portraitUrl (id, hash) {
+    return getPortraitUrl ? getPortraitUrl(id, hash) : ''
+  }
 
   export let user
   export let clearUnread
@@ -53,7 +59,8 @@
     }
   })
 
-  onMount(() => {
+  onMount(async () => {
+    ({ supabase, handleError, getPortraitUrl } = await import('@lib/database-browser'))
     // init conversation, listen for new messages in the conversation. we can listen to only 'us' in the recipient column
     const filter = `${recipientColumn}=eq.${us.id}` // not possible to filter for two columns at the moment, so we have to filter the sender on the client-side
     channel = supabase
@@ -263,7 +270,7 @@
         {:then}
           <h2>
             {#if them.portrait}
-              <img src={getPortraitUrl(them.id, them.portrait)} class='portrait' alt={them.name} />
+              <img src={portraitUrl(them.id, them.portrait)} class='portrait' alt={them.name} />
             {/if}
             <div class='label'>
               {#if $activeConversation.type === 'character'}

--- a/src/components/sidebar/People.svelte
+++ b/src/components/sidebar/People.svelte
@@ -2,14 +2,22 @@
   import { onMount } from 'svelte'
   import { tooltip } from '@lib/tooltip'
   import { showSuccess } from '@lib/toasts'
-  import { supabase, getPortraitUrl, handleError } from '@lib/database-browser'
+  
+  let supabase
+  let getPortraitUrl
+  let handleError
 
   const { user, users = [], openConversation } = $props()
 
   let groups = $state({ unread: [], active: [], contacts: [] })
   let showContacts = $state(false)
 
-  onMount(() => {
+  function portraitUrl (id, hash) {
+    return getPortraitUrl ? getPortraitUrl(id, hash) : ''
+  }
+
+  onMount(async () => {
+    ({ supabase, getPortraitUrl, handleError } = await import('@lib/database-browser'))
     const next = { unread: [], active: [], contacts: [] }
     users.forEach(user => {
       if (user.unread) {
@@ -37,7 +45,7 @@
       <li>
         <button class='opener' onclick={() => openConversation({ them: user, type: 'user' })}>
           {#if user.portrait}
-            <img src={getPortraitUrl(user.id, user.portrait)} class='portrait' alt={user.name} />
+            <img src={portraitUrl(user.id, user.portrait)} class='portrait' alt={user.name} />
           {:else}
             <span class='gap'></span>
           {/if}
@@ -62,7 +70,7 @@
         <li>
           <button class='opener' onclick={() => openConversation({ them: user, type: 'user' })}>
             {#if user.portrait}
-              <img src={getPortraitUrl(user.id, user.portrait)} class='portrait' alt={user.name} />
+              <img src={portraitUrl(user.id, user.portrait)} class='portrait' alt={user.name} />
             {:else}
               <span class='gap'></span>
             {/if}
@@ -82,7 +90,7 @@
         <li class:offline={!user.active} class='row'>
           <button class='opener' onclick={() => openConversation({ them: user, type: 'user' })}>
             {#if user.portrait}
-              <img src={getPortraitUrl(user.id, user.portrait)} class='portrait' alt={user.name} />
+              <img src={portraitUrl(user.id, user.portrait)} class='portrait' alt={user.name} />
             {:else}
               <span class='gap'></span>
             {/if}

--- a/src/components/sidebar/Sidebar.svelte
+++ b/src/components/sidebar/Sidebar.svelte
@@ -1,6 +1,5 @@
 <script>
   import { onMount, onDestroy } from 'svelte'
-  import { supabase, handleError } from '@lib/database-browser'
   import { redirectWithToast, isFilledArray } from '@lib/utils'
   import { getSavedStore, activeConversation, bookmarks } from '@lib/stores'
   import User from '@components/sidebar/User.svelte'
@@ -43,8 +42,11 @@
   // loading states
   let loading = $state(false)
   let currentTab = $state('')
+  let supabase
+  let handleError
 
   onMount(async () => {
+    ({ supabase, handleError } = await import('@lib/database-browser'))
     userStore = getSavedStore('user')
     $userStore.activePanel = $userStore.activePanel || 'booked'
     document.getElementById($userStore.activePanel)?.classList.add('active')

--- a/src/components/sidebar/User.svelte
+++ b/src/components/sidebar/User.svelte
@@ -1,11 +1,16 @@
 <script>
+  import { onMount } from 'svelte'
   import { tooltip } from '@lib/tooltip'
-  import { supabase } from '@lib/database-browser'
   import { uploadPortrait } from '@lib/utils'
   import { activeConversation } from '@lib/stores'
   import PortraitInput from '@components/common/PortraitInput.svelte'
 
   const { user = {} } = $props()
+  let supabase
+
+  onMount(async () => {
+    ({ supabase } = await import('@lib/database-browser'))
+  })
 
   async function onPortraitChange (file) {
     await uploadPortrait(supabase, user.id, 'profiles', file)

--- a/src/layouts/layout.astro
+++ b/src/layouts/layout.astro
@@ -37,6 +37,8 @@ if (user.id) {
     <!-- fonts -->
     <link rel='preconnect' href='https://fonts.googleapis.com'>
     <link rel='preconnect' href='https://fonts.gstatic.com' crossorigin>
+    <link rel='preload' as='style' href='https://fonts.googleapis.com/css2?family=Alegreya:ital,wght@0,400;0,900;1,400;1,900&display=swap'>
+    <link rel='preload' as='style' href='https://fonts.googleapis.com/css2?family=Caveat:wght@400..700&family=Inter:wght@100..900&family=Orbitron:wght@400..900&display=swap'>
     <link rel='stylesheet' href='https://fonts.googleapis.com/css2?family=Alegreya:ital,wght@0,400;0,900;1,400;1,900&display=swap'>
     <link rel='stylesheet' href='https://fonts.googleapis.com/css2?family=Caveat:wght@400..700&family=Inter:wght@100..900&family=Orbitron:wght@400..900&display=swap'>
     <!-- font css response output placed manually to base.css, as workaround for google not serving properly to opera gx -->
@@ -61,7 +63,7 @@ if (user.id) {
     <HeaderCrop client:only='svelte' />
     <div id='wrapper'>
       <main>
-        <Header {pathname} {headerStatic} {headerStorage} {chatUnread} client:only='svelte' />
+        <Header {pathname} {headerStatic} {headerStorage} {chatUnread} client:load />
         <div class='content'>
           <Arrows client:only='svelte' />
           <slot />
@@ -78,7 +80,7 @@ if (user.id) {
       </main>
       <!-- show sidebar when logged in or logged out, not in onboarding when name is missing -->
       {(user.name || (!user.name && !user.email)) ? (
-        <Sidebar {pathname} {user} client:only='svelte' />
+        <Sidebar {pathname} {user} client:load />
       ) : null}
     </div>
     <!-- analytics -->

--- a/src/layouts/layoutChat.astro
+++ b/src/layouts/layoutChat.astro
@@ -27,6 +27,8 @@ const { title, headerStatic, headerStorage } = Astro.props
     <!-- fonts -->
     <link rel='preconnect' href='https://fonts.googleapis.com'>
     <link rel='preconnect' href='https://fonts.gstatic.com' crossorigin>
+    <link rel='preload' as='style' href='https://fonts.googleapis.com/css2?family=Alegreya:ital,wght@0,400;0,900;1,400;1,900&display=swap'>
+    <link rel='preload' as='style' href='https://fonts.googleapis.com/css2?family=Caveat:wght@400..700&family=Inter:wght@100..900&family=Orbitron:wght@400..900&display=swap'>
     <link rel='stylesheet' href='https://fonts.googleapis.com/css2?family=Alegreya:ital,wght@0,400;0,900;1,400;1,900&display=swap'>
     <link rel='stylesheet' href='https://fonts.googleapis.com/css2?family=Caveat:wght@400..700&family=Inter:wght@100..900&family=Orbitron:wght@400..900&display=swap'>
     <!-- font css response output placed manually to base.css, as workaround for google not serving properly to opera gx -->
@@ -50,7 +52,7 @@ const { title, headerStatic, headerStorage } = Astro.props
       </main>
       <!-- show sidebar when logged in or logged out, not in onboarding when name is missing -->
       {(user.name || (!user.name && !user.email)) ? (
-        <Sidebar {pathname} {user} client:only='svelte' />
+        <Sidebar {pathname} {user} client:load />
       ) : null}
     </div>
     <!-- analytics -->

--- a/src/layouts/layoutSolo.astro
+++ b/src/layouts/layoutSolo.astro
@@ -36,6 +36,8 @@ if (user.id) {
     <!-- fonts -->
     <link rel='preconnect' href='https://fonts.googleapis.com'>
     <link rel='preconnect' href='https://fonts.gstatic.com' crossorigin>
+    <link rel='preload' as='style' href='https://fonts.googleapis.com/css2?family=Alegreya:ital,wght@0,400;0,900;1,400;1,900&display=swap'>
+    <link rel='preload' as='style' href='https://fonts.googleapis.com/css2?family=Caveat:wght@400..700&family=Inter:wght@100..900&family=Orbitron:wght@400..900&display=swap'>
     <link rel='stylesheet' href='https://fonts.googleapis.com/css2?family=Alegreya:ital,wght@0,400;0,900;1,400;1,900&display=swap'>
     <link rel='stylesheet' href='https://fonts.googleapis.com/css2?family=Caveat:wght@400..700&family=Inter:wght@100..900&family=Orbitron:wght@400..900&display=swap'>
     <!-- font css response output placed manually to base.css, as workaround for google not serving properly to opera gx -->
@@ -60,7 +62,7 @@ if (user.id) {
     <HeaderCrop client:only='svelte' />
     <div id='wrapper'>
       <main>
-        <Header {pathname} {headerStatic} {headerStorage} {chatUnread} client:only='svelte' />
+        <Header {pathname} {headerStatic} {headerStorage} {chatUnread} client:load />
         <div class='content'>
           <slot />
         </div>
@@ -78,7 +80,7 @@ if (user.id) {
       </main>
       <!-- show sidebar when logged in or logged out, not in onboarding when name is missing -->
       {(user.name || (!user.name && !user.email)) ? (
-        <Sidebar {pathname} {user} client:only='svelte' />
+        <Sidebar {pathname} {user} client:load />
       ) : null}
     </div>
     <!-- analytics -->


### PR DESCRIPTION
## Summary
- Load header and sidebar on the client after server-side render instead of using `client:only`
- Delay Supabase initialization to browser-only on mount
- Preload Google Fonts to reduce layout shifts

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aefdb0dca8832f817007678cc0e2cf