### PR TITLE
feat: add tone of voice for solo games

### DIFF
--- a/src/components/solo/ConceptForm.svelte
+++ b/src/components/solo/ConceptForm.svelte
@@ -1,6 +1,6 @@
 <script>
   import Select from 'svelte-select'
-  import { gameTags } from '@lib/constants'
+  import { gameTags, soloTones } from '@lib/constants'
   import { preventSubmit } from '@lib/utils'
   import { illustrationStyles } from '@lib/solo/solo'
   import TextareaExpandable from '@components/common/TextareaExpandable.svelte'
@@ -19,7 +19,8 @@
     promptCharacters: '',
     promptHeaderImage: '',
     promptStorytellerImage: '',
-    illustrationStyle: 'ink'
+    illustrationStyle: 'ink',
+    tone: 'neutral'
   }
 
   const conceptStore = getSavedStore('soloConceptForm', defaultConcept)
@@ -103,21 +104,32 @@
       <center><button type='button' class='small' onclick={() => { showAdvanced = true }}>Zobrazit pokročilé</button></center>
     {/if}
 
-    <div class='row'>
-      <div class='labels'>Styl ilustrace</div>
-      <div class='inputs'>
-        <select bind:value={$conceptStore.illustrationStyle} name='illustrationStyle' class='styleSelect'>
-          {#each illustrationStyles as style (style.value)}
-            <option value={style.value}>{style.label}</option>
-          {/each}
-        </select>
-      </div>
+  <div class='row'>
+    <div class='labels'>Styl ilustrace</div>
+    <div class='inputs'>
+      <select bind:value={$conceptStore.illustrationStyle} name='illustrationStyle' class='styleSelect'>
+        {#each illustrationStyles as style (style.value)}
+          <option value={style.value}>{style.label}</option>
+        {/each}
+      </select>
     </div>
+  </div>
+
+  <div class='row'>
+    <div class='labels'>Žánr vyprávění</div>
+    <div class='inputs'>
+      <select bind:value={$conceptStore.tone} name='tone' class='styleSelect'>
+        {#each soloTones as tone (tone.value)}
+          <option value={tone.value}>{tone.label}</option>
+        {/each}
+      </select>
+    </div>
+  </div>
 
     <div class='row'>
       <div class='labels'><label for='soloTags'>Tagy<span class='info'>(max 3)</span></label></div>
-      <div class='inputs'>
-        <Select items={maxTags ? [] : tagItems} multiple bind:value={selectedTags} placeholder=''>
+    <div class='inputs'>
+      <Select items={maxTags ? [] : tagItems} multiple bind:value={selectedTags} placeholder=''>
           {#snippet empty()}<div >Více tagů nelze přidat</div>{/snippet}
         </Select>
         <input type='hidden' name='soloTags' bind:this={tagsInputRef} />

--- a/src/components/solo/ConceptSettings.svelte
+++ b/src/components/solo/ConceptSettings.svelte
@@ -1,7 +1,7 @@
 <script>
   import Select from 'svelte-select'
   import { tooltip } from '@lib/tooltip'
-  import { gameTags } from '@lib/constants'
+  import { gameTags, soloTones } from '@lib/constants'
   import { onDestroy } from 'svelte'
   import { showSuccess } from '@lib/toasts'
   import { clone, getStamp, uploadPortrait } from '@lib/utils'
@@ -294,6 +294,15 @@
       <select bind:value={concept.illustration_style} onchange={() => onSave('illustration_style')} class='styleSelect'>
         {#each illustrationStyles as style (style.value)}
           <option value={style.value}>{style.label}</option>
+        {/each}
+      </select>
+    </div>
+
+    <h2>Žánr vyprávění</h2>
+    <div class='row'>
+      <select bind:value={concept.tone} onchange={() => onSave('tone')} class='styleSelect'>
+        {#each soloTones as tone (tone.value)}
+          <option value={tone.value}>{tone.label}</option>
         {/each}
       </select>
     </div>

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -53,6 +53,7 @@ create type work_type as enum ('text', 'image', 'audio');
 create type work_tag as enum ( 'story', 'continued', 'preview', 'thought', 'fanfiction', 'scifi', 'fantasy', 'mythology', 'horror', 'detective', 'romance', 'fairytale', 'dystopia', 'humorous', 'fromlife', 'motivational', 'biography', 'gameworld', 'gamematerial', 'editorial', 'announcement', 'project', 'erotica', 'portrait', 'landscape', 'abstract', 'guitar', 'piano', 'orchestral', 'electronic' );
 create type work_category as enum ( 'prose', 'poetry', 'game', 'painting', 'drawing', 'photo', 'digital', 'instrumental', 'vocal', 'ambient', 'other' );
 create type post_content_type as enum ('game', 'other');
+create type solo_tone as enum ('neutral', 'horror', 'comedy', 'drama', 'noir', 'romance', 'scifi', 'fantasy');
 
 
 -- TABLES --------------------------------------------
@@ -122,6 +123,7 @@ create table solo_concepts (
   custom_header text,
   storyteller uuid,
   illustration_style text default 'ink'::text,
+  tone public.solo_tone not null default 'neutral'::solo_tone,
   protagonist_names text[],
   prompt_world text,
   prompt_protagonist text,

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -57,6 +57,17 @@ export const gameTags = [
   { value: 'other', label: 'Ostatní' }
 ]
 
+export const soloTones = [
+  { value: 'neutral', label: 'Neutrální' },
+  { value: 'horror', label: 'Horor' },
+  { value: 'comedy', label: 'Komedie' },
+  { value: 'drama', label: 'Drama' },
+  { value: 'noir', label: 'Noir' },
+  { value: 'romance', label: 'Romantický' },
+  { value: 'scifi', label: 'Sci-fi' },
+  { value: 'fantasy', label: 'Fantasy' }
+]
+
 export const workCategoriesText = [
   { value: 'prose', label: 'Próza' },
   { value: 'poetry', label: 'Poezie' },

--- a/src/lib/solo/server-gemini.js
+++ b/src/lib/solo/server-gemini.js
@@ -1,12 +1,19 @@
 import { GoogleGenAI } from '@google/genai'
 import { illustrationStyleAffixes, storytellerInstructions, getResponseSchema } from '@lib/solo/solo'
+import { soloTones } from '@lib/constants'
 
 export const getStorytellerParams = (concept, history, npcSlugs, systemInstruction) => {
   const illustrationStyleAffix = illustrationStyleAffixes[concept.illustration_style] || 'ink'
   const responseSchema = getResponseSchema(illustrationStyleAffix)
 
   if (npcSlugs) { responseSchema.properties.character.properties.slug.enum = npcSlugs } // Update the enum with available NPC slugs
-  if (!systemInstruction) { systemInstruction = storytellerInstructions }
+  if (!systemInstruction) {
+    systemInstruction = storytellerInstructions
+    const toneLabel = soloTones.find(t => t.value === concept.tone)?.label
+    if (toneLabel && concept.tone !== 'neutral') {
+      systemInstruction += ` Vyprávěj v žánru: ${toneLabel.toLowerCase()}.`
+    }
+  }
 
   return {
     model: 'gemini-2.5-pro',

--- a/src/lib/solo/solo.js
+++ b/src/lib/solo/solo.js
@@ -53,7 +53,7 @@ export const assistantParams = {
 
 export const storytellerInstructions = `Jsi vypravěč (storyteller nebo game-master) online TTRPG hry.
 
-Herní styl: Hra je pro jednoho hráče, v češtině. Hraje se bez pravidel, čistý roleplaying. Ty (vypravěč) rozhoduješ o všem způsobem, který je realistický a vede buď k zajímavému pokračování, nebo k ukončení hry. Neexistuje žádný herní systém, jen příběh, postavy a rozhodnutí.
+Herní styl: Hra je pro jednoho hráče, v češtině. Hraje se bez pravidel, čistý roleplaying. Ty (vypravěč) rozhoduješ o všem způsobem, který je realistický a vede buď k zajímavému pokračování, nebo k ukončení hry. Neexistuje žádný herní systém, jen příběh, postavy a rozhodnutí. Tón vyprávění přizpůsob vybranému žánru.
 
 Výstup: Výstup musí být v JSON formátu. Pro textový obsah příspěvku použij klíč "post", v HTML formátu. Používej jen základní tagy: kurzíva pro myšlenky a tučné písmo pro přímou řeč. Žádné nadpisy, seznamy, odkazy, emoji ani CSS.
 

--- a/src/pages/api/solo/generatePost.js
+++ b/src/pages/api/solo/generatePost.js
@@ -4,6 +4,7 @@ import { getImageUrl, getStamp } from '@lib/utils'
 import { getStorytellerParams, getAI } from '@lib/solo/server-moonshot'
 import { createSSEStream, getSSEHeaders } from '@lib/solo/server-utils'
 import { storytellerInstructions, getContext, illustrationStyleAffixes, getResponseSchema } from '@lib/solo/solo'
+import { soloTones } from '@lib/constants'
 
 const imageBuckets = { header: 'headers', scene: 'scenes', item: 'items', npc: 'npcs' }
 
@@ -68,6 +69,10 @@ export const POST = async ({ request, locals }) => {
         <h2>Plán hry:</h2>
         ${conceptData.generated_plan}
       `
+      const toneLabel = soloTones.find(t => t.value === conceptData.tone)?.label
+      if (toneLabel && conceptData.tone !== 'neutral') {
+        systemInstruction += `\nVyprávěj v žánru: ${toneLabel.toLowerCase()}.`
+      }
       const illustrationStyleAffix = illustrationStyleAffixes[conceptData.illustration_style] || 'ink'
       const responseSchema = getResponseSchema(illustrationStyleAffix)
       if (npcSlugs) { responseSchema.properties.character.properties.slug.enum = npcSlugs } // Update the enum with available NPC slugs

--- a/src/pages/solo/concept/concept-form.astro
+++ b/src/pages/solo/concept/concept-form.astro
@@ -8,8 +8,8 @@
   if (Astro.request.method === 'POST') {
     const formData = await Astro.request.formData()
     const tags = formData.get('soloTags') ? formData.get('soloTags').split(',') : []
-    const fields = ['conceptName', 'promptWorld', 'promptPlan', 'promptFactions', 'promptLocations', 'promptCharacters', 'promptProtagonist', 'promptHeaderImage', 'promptStorytellerImage', 'illustrationStyle']
-    const [name, world, plan, factions, locations, characters, protagonist, promptHeaderImage, promptStorytellerImage, illustrationStyle] = fields.map(field => formData.get(field))
+    const fields = ['conceptName', 'promptWorld', 'promptPlan', 'promptFactions', 'promptLocations', 'promptCharacters', 'promptProtagonist', 'promptHeaderImage', 'promptStorytellerImage', 'illustrationStyle', 'tone']
+    const [name, world, plan, factions, locations, characters, protagonist, promptHeaderImage, promptStorytellerImage, illustrationStyle, tone] = fields.map(field => formData.get(field))
     const storytellerImage = formData.get('newPortrait')
 
     if (!name) { return Astro.redirect(`/?toastType=error&toastText=${encodeURIComponent('Chyba: Prosím vyplň jméno herního konceptu.')}`) }
@@ -22,7 +22,7 @@
 
       // Create the concept record
       const { data: conceptData, error } = await supabase.from('solo_concepts').insert({
-        author: user.id, name, prompt_world: world, prompt_plan: plan, prompt_protagonist: protagonist, prompt_locations: locations, prompt_factions: factions, prompt_characters: characters, prompt_header_image: promptHeaderImage, prompt_storyteller_image: promptStorytellerImage, tags, illustration_style: illustrationStyle,
+        author: user.id, name, prompt_world: world, prompt_plan: plan, prompt_protagonist: protagonist, prompt_locations: locations, prompt_factions: factions, prompt_characters: characters, prompt_header_image: promptHeaderImage, prompt_storyteller_image: promptStorytellerImage, tags, illustration_style: illustrationStyle, tone,
         generating
       }).select().single()
 


### PR DESCRIPTION
## Summary
- allow selecting narrative tone for solo game concepts
- update schema and storyteller instructions to respect selected tone

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: callback is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68c489ec150c832fbfc20a077a8cd509