### PR TITLE
Add publish consent option and modal

### DIFF
--- a/src/components/user/PublishConsentModal.svelte
+++ b/src/components/user/PublishConsentModal.svelte
@@ -1,0 +1,54 @@
+<script>
+  import { supabase } from '@lib/database-browser'
+  import { showError } from '@lib/toasts'
+
+  let { user = $bindable() } = $props()
+  const open = $derived.by(() => user && user.publish_consent === null)
+
+  async function setConsent (value) {
+    const { error } = await supabase.from('profiles').update({ publish_consent: value }).eq('id', user.id)
+    if (error) { return showError(error.message) }
+    user.publish_consent = value
+  }
+</script>
+
+{#if open}
+  <div id='consentVeil'></div>
+  <div id='consentModal'>
+    <p>Souhlasíš s publikováním tvých příspěvků z veřejných her na hlavní stránce a sociálních sítích pod jménem tvé postavy?</p>
+    <div class='buttons'>
+      <button onclick={() => setConsent(true)}>Souhlasím</button>
+      <button onclick={() => setConsent(false)}>Nesouhlasím</button>
+    </div>
+  </div>
+{/if}
+
+<style>
+  #consentVeil {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #000;
+    opacity: 0.5;
+    z-index: 999;
+  }
+  #consentModal {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background: var(--panel);
+    padding: 20px;
+    border-radius: 10px;
+    z-index: 1000;
+    max-width: 500px;
+  }
+    #consentModal .buttons {
+      margin-top: 20px;
+      display: flex;
+      gap: 20px;
+      justify-content: center;
+    }
+</style>

--- a/src/components/user/Settings.svelte
+++ b/src/components/user/Settings.svelte
@@ -11,6 +11,7 @@
   let password2 = $state('')
   let newEmail = $state(user.email)
   let originalAutorefresh = $state(user.autorefresh)
+  let originalPublishConsent = $state(user.publish_consent)
   // let originalEditorBubble = user.editor_bubble
   let originalTheme = $state(user.theme)
   let newColor = $state('')
@@ -27,6 +28,7 @@
   async function updateUser (theme = false) {
     const data = {
       autorefresh: user.autorefresh,
+      publish_consent: user.publish_consent,
       // editor_bubble: user.editor_bubble,
       theme: user.theme,
       colors: user.colors
@@ -34,6 +36,7 @@
     const { error } = await supabase.from('profiles').update(data).eq('id', user.id)
     if (error) { return showError(error.message) }
     originalAutorefresh = user.autorefresh
+    originalPublishConsent = user.publish_consent
     // originalEditorBubble = user.editor_bubble
     originalTheme = user.theme
     showSuccess('Nastavení bylo uloženo')
@@ -144,6 +147,15 @@
       <input type='color' id='nameColor' name='nameColor' bind:value={newColor} />
       <input type='text' bind:value={newColor}>
       <button onclick={addColor} class='material square' title='Uložit' use:tooltip>check</button>
+    </div>
+
+    <h2>Publikování příspěvků</h2>
+    <div class='rowInner'>
+      <select bind:value={user.publish_consent} id='publishConsent' name='publishConsent'>
+        <option value={true}>Souhlasím</option>
+        <option value={false}>Nesouhlasím</option>
+      </select>
+      <button onclick={updateUser} class='material' disabled={originalPublishConsent === user.publish_consent} title='Uložit' use:tooltip>check</button>
     </div>
 
     <h2>Auto-refresh herních příspěvků</h2>

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -68,6 +68,7 @@ create table profiles (
   theme text default 'obsidian',
   solo_limit int4 default 10,
   autorefresh boolean default false,
+  publish_consent boolean,
   -- editor_bubble boolean default false,
   colors text[] default '{}',
   constraint profiles_id_fkey foreign key (id) references auth.users(id) on delete cascade

--- a/src/layouts/layout.astro
+++ b/src/layouts/layout.astro
@@ -7,6 +7,7 @@ import Store from '@components/common/Store.svelte'
 import Arrows from '@components/common/Arrows.svelte'
 import Lightbox from '@components/common/Lightbox.svelte'
 import HeaderCrop from '@components/common/HeaderCrop.svelte'
+import PublishConsentModal from '@components/user/PublishConsentModal.svelte'
 import { ViewTransitions } from 'astro:transitions'
 
 const { version } = pkg
@@ -59,6 +60,7 @@ if (user.id) {
 	<body>
     <Lightbox client:only='svelte' />
     <HeaderCrop client:only='svelte' />
+    <PublishConsentModal user={user} client:only='svelte' />
     <div id='wrapper'>
       <main>
         <Header {pathname} {headerStatic} {headerStorage} {chatUnread} client:only='svelte' />

--- a/supabase/migrations/20250913121200_add_publish_consent_to_profiles.sql
+++ b/supabase/migrations/20250913121200_add_publish_consent_to_profiles.sql
@@ -1,0 +1,1 @@
+alter table public.profiles add column publish_consent boolean;


### PR DESCRIPTION
## Summary
- add `publish_consent` column to profiles and migration
- allow users to toggle publication of public game posts in settings
- show modal prompting for publishing consent when unset

## Testing
- `npm test` *(fails: Missing script)*
- `npx eslint src/components/user/Settings.svelte src/components/user/PublishConsentModal.svelte src/layouts/layout.astro`


------
https://chatgpt.com/codex/tasks/task_e_68c55e85c634832f829af41d6e5a6413