### PR TITLE
Add weekly post voting and Monday announcement

### DIFF
--- a/src/components/common/Post.svelte
+++ b/src/components/common/Post.svelte
@@ -8,7 +8,7 @@
   import { supabase, handleError, getPortraitUrl } from '@lib/database-browser'
   import Reactions from '@components/common/Reactions.svelte'
 
-  const { post, user = null, unread = false, isMyPost = false, allowReactions = false, canDeleteAll = false, canModerate = false, onModerate = null, onDelete = null, onEdit = null, onReply = null, iconSize = 70, showEdited = true } = $props()
+  const { post, user = null, unread = false, isMyPost = false, allowReactions = false, allowedReactions = ['frowns', 'laughs', 'shocks', 'hearts', 'thumbs'], canDeleteAll = false, canModerate = false, onModerate = null, onDelete = null, onEdit = null, onReply = null, iconSize = 70, showEdited = true } = $props()
 
   let expanded = $state(false)
   let contentEl = $state()
@@ -118,7 +118,7 @@
       {/if}
       <div class='clear'></div>
       {#if allowReactions}
-        <Reactions {user} {post} type='post' />
+        <Reactions {user} {post} type='post' allowed={allowedReactions} />
       {/if}
     </div>
   </div>

--- a/src/components/common/Reactions.svelte
+++ b/src/components/common/Reactions.svelte
@@ -1,7 +1,7 @@
 <script>
   import { supabase, handleError } from '@lib/database-browser'
 
-  const { user = {}, post = {}, type = 'post' } = $props()
+  const { user = {}, post = {}, type = 'post', allowed = ['frowns', 'laughs', 'shocks', 'hearts', 'thumbs'] } = $props()
 
   function getMyReaction (reaction) {
     return post[reaction]?.findIndex((id) => { return id === user.id })
@@ -24,19 +24,29 @@
 
 {#if user.id && post.owner !== user.id}
   <span class='reactions'>
-    <button onclick={() => { toggleReaction('frowns') }} class:active={hasReacted('frowns')} class='reaction frowns' title='Smutek'><img src='/svg/frown.svg' alt='Smutek' class='svg'>{#if post.frowns?.length}<span class='count'>{post.frowns.length}</span>{/if}</button>
-    <button onclick={() => { toggleReaction('laughs') }} class:active={hasReacted('laughs')} class='reaction laughs' title='Smích'><img src='/svg/laugh.svg' alt='Smích' class='svg'>{#if post.laughs?.length}<span class='count'>{post.laughs.length}</span>{/if}</button>
-    <button onclick={() => { toggleReaction('shocks') }} class:active={hasReacted('shocks')} class='reaction shocks' title='Šok'><img src='/svg/shock.svg' alt='Šok' class='svg'>{#if post.shocks?.length}<span class='count'>{post.shocks.length}</span>{/if}</button>
-    <button onclick={() => { toggleReaction('hearts') }} class:active={hasReacted('hearts')} class='reaction hearts' title='Srdce'><img src='/svg/heart.svg' alt='Srdce' class='svg'>{#if post.hearts?.length}<span class='count'>{post.hearts.length}</span>{/if}</button>
-    <button onclick={() => { toggleReaction('thumbs') }} class:active={hasReacted('thumbs')} class='reaction thumbs' title='Palec nahoru'><img src='/svg/thumb.svg' alt='Palec nahoru' class='svg'>{#if post.thumbs?.length}<span class='count'>{post.thumbs.length}</span>{/if}</button>
+    {#if allowed.includes('frowns')}
+      <button onclick={() => { toggleReaction('frowns') }} class:active={hasReacted('frowns')} class='reaction frowns' title='Smutek'><img src='/svg/frown.svg' alt='Smutek' class='svg'>{#if post.frowns?.length}<span class='count'>{post.frowns.length}</span>{/if}</button>
+    {/if}
+    {#if allowed.includes('laughs')}
+      <button onclick={() => { toggleReaction('laughs') }} class:active={hasReacted('laughs')} class='reaction laughs' title='Smích'><img src='/svg/laugh.svg' alt='Smích' class='svg'>{#if post.laughs?.length}<span class='count'>{post.laughs.length}</span>{/if}</button>
+    {/if}
+    {#if allowed.includes('shocks')}
+      <button onclick={() => { toggleReaction('shocks') }} class:active={hasReacted('shocks')} class='reaction shocks' title='Šok'><img src='/svg/shock.svg' alt='Šok' class='svg'>{#if post.shocks?.length}<span class='count'>{post.shocks.length}</span>{/if}</button>
+    {/if}
+    {#if allowed.includes('hearts')}
+      <button onclick={() => { toggleReaction('hearts') }} class:active={hasReacted('hearts')} class='reaction hearts' title='Srdce'><img src='/svg/heart.svg' alt='Srdce' class='svg'>{#if post.hearts?.length}<span class='count'>{post.hearts.length}</span>{/if}</button>
+    {/if}
+    {#if allowed.includes('thumbs')}
+      <button onclick={() => { toggleReaction('thumbs') }} class:active={hasReacted('thumbs')} class='reaction thumbs' title='Palec nahoru'><img src='/svg/thumb.svg' alt='Palec nahoru' class='svg'>{#if post.thumbs?.length}<span class='count'>{post.thumbs.length}</span>{/if}</button>
+    {/if}
   </span>
 {:else}
   <span class='reactions'>
-    {#if post.frowns?.length}<span class='reaction frowns' title='Smutek'><img src='/svg/frown.svg' alt='Smutek' class='svg'><span class='count'>{post.frowns?.length}</span></span>{/if}
-    {#if post.laughs?.length}<span class='reaction laughs' title='Smích'><img src='/svg/laugh.svg' alt='Smích' class='svg'><span class='count'>{post.laughs?.length}</span></span>{/if}
-    {#if post.shocks?.length}<span class='reaction shocks' title='Šok'><img src='/svg/shock.svg' alt='Šok' class='svg'><span class='count'>{post.shocks?.length}</span></span>{/if}
-    {#if post.hearts?.length}<span class='reaction hearts' title='Srdce'><img src='/svg/heart.svg' alt='Srdce' class='svg'><span class='count'>{post.hearts?.length}</span></span>{/if}
-    {#if post.thumbs?.length}<span class='reaction thumbs' title='Palec nahoru'><img src='/svg/thumb.svg' alt='Palec nahoru' class='svg'><span class='count'>{post.thumbs?.length}</span></span>{/if}
+    {#if allowed.includes('frowns') && post.frowns?.length}<span class='reaction frowns' title='Smutek'><img src='/svg/frown.svg' alt='Smutek' class='svg'><span class='count'>{post.frowns?.length}</span></span>{/if}
+    {#if allowed.includes('laughs') && post.laughs?.length}<span class='reaction laughs' title='Smích'><img src='/svg/laugh.svg' alt='Smích' class='svg'><span class='count'>{post.laughs?.length}</span></span>{/if}
+    {#if allowed.includes('shocks') && post.shocks?.length}<span class='reaction shocks' title='Šok'><img src='/svg/shock.svg' alt='Šok' class='svg'><span class='count'>{post.shocks?.length}</span></span>{/if}
+    {#if allowed.includes('hearts') && post.hearts?.length}<span class='reaction hearts' title='Srdce'><img src='/svg/heart.svg' alt='Srdce' class='svg'><span class='count'>{post.hearts?.length}</span></span>{/if}
+    {#if allowed.includes('thumbs') && post.thumbs?.length}<span class='reaction thumbs' title='Palec nahoru'><img src='/svg/thumb.svg' alt='Palec nahoru' class='svg'><span class='count'>{post.thumbs?.length}</span></span>{/if}
   </span>
 {/if}
 

--- a/src/components/homepage/PotwAnnouncement.svelte
+++ b/src/components/homepage/PotwAnnouncement.svelte
@@ -1,0 +1,60 @@
+<script>
+  import DOMPurify from 'dompurify'
+  import { onMount } from 'svelte'
+  import { slide } from 'svelte/transition'
+  import { getSavedStore } from '@lib/stores'
+
+  const { winner = null, weekId } = $props()
+
+  let show = $state(false)
+  let userStore
+
+  onMount(() => {
+    userStore = getSavedStore('user')
+    if ($userStore.lastClosedPotw !== weekId) {
+      show = true
+    }
+  })
+
+  function close () {
+    show = false
+    $userStore.lastClosedPotw = weekId
+  }
+</script>
+
+{#if winner && show}
+  <div id='potw' transition:slide={{ duration: 300 }}>
+    <h4>Příspěvek týdne</h4>
+    <section>{@html DOMPurify.sanitize(winner.content)}</section>
+    <p><a href='/post-of-the-week'>Hlasovat o příspěvek týdne</a></p>
+    <button onclick={close} class='close' title='Skrýt'>
+      <span class='material'>check</span>
+    </button>
+  </div>
+{/if}
+
+<style>
+  #potw {
+    padding: 20px;
+    padding-bottom: 10px;
+    margin-bottom: 20px;
+    background-color: var(--prominent);
+    position: relative;
+    overflow: hidden;
+  }
+  #potw h4 {
+    margin-top: 0px;
+    margin-bottom: 0px;
+    font-size: 18px;
+  }
+  #potw section {
+    margin-top: 10px;
+  }
+  #potw button {
+    position: absolute;
+    top: 0px;
+    right: 0px;
+    border-radius: 0px 0px 0px 10px;
+    padding: 8px 10px 5px 11px;
+  }
+</style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,9 +4,10 @@
   import NewsFeed from '@components/homepage/NewsFeed.svelte'
   import NewsItem from '@components/homepage/NewsItem.svelte'
   import Editorial from '@components/homepage/Editorial.svelte'
+  import PotwAnnouncement from '@components/homepage/PotwAnnouncement.svelte'
 
-  let newsError, lastEditorial, news, maxPage, npcPost
-	const { supabase, user } = Astro.locals
+  let newsError, lastEditorial, news, maxPage, npcPost, potw, potwWeekId
+        const { supabase, user } = Astro.locals
 	const params = Object.fromEntries(Astro.url.searchParams)
 
 	try {
@@ -50,6 +51,31 @@
       newsError = 'Chyba načtení příspěvku: ' + error.message
     }
   }
+
+  // Post of the week winner announcement
+  const today = new Date()
+  if (today.getDay() === 1) {
+    const currentWeekStart = new Date(today)
+    currentWeekStart.setHours(0, 0, 0, 0)
+    currentWeekStart.setDate(currentWeekStart.getDate() - ((currentWeekStart.getDay() + 6) % 7))
+    const previousWeekStart = new Date(currentWeekStart)
+    previousWeekStart.setDate(previousWeekStart.getDate() - 7)
+    potwWeekId = currentWeekStart.toISOString().slice(0, 10)
+    try {
+      const { data: weekPosts, error: potwError } = await supabase
+        .from('game_posts_owner')
+        .select('*')
+        .gte('created_at', previousWeekStart.toISOString())
+        .lt('created_at', currentWeekStart.toISOString())
+        .or('audience.is.null,audience.eq.{}')
+      if (potwError) { throw potwError }
+      if (weekPosts && weekPosts.length) {
+        potw = weekPosts.reduce((best, p) => ((p.hearts?.length || 0) > (best.hearts?.length || 0) ? p : best), weekPosts[0])
+      }
+    } catch (error) {
+      // ignore errors, don't block page rendering
+    }
+  }
 ---
 
 <Layout title='RPG hry online: Dračí Doupě (DrD), Dungeons and Dragons (D&D, DnD), AI vypravěč'>
@@ -57,7 +83,8 @@
     <h1>TTRPG: Stolní RPG hry online - Dračí Doupě (DrD), Dungeons and Dragons (D&D, DnD) a další</h1>
   ) : null}
   {newsError ? <p>{newsError}</p> : <Editorial {lastEditorial} client:only='svelte' />}
-	<main>
+  <PotwAnnouncement winner={potw} weekId={potwWeekId} client:only='svelte' />
+        <main>
 		<aside>
 			<Latest client:only='svelte' />
 		</aside>

--- a/src/pages/post-of-the-week.astro
+++ b/src/pages/post-of-the-week.astro
@@ -1,0 +1,35 @@
+---
+import Layout from '@layouts/layout.astro'
+import Post from '@components/common/Post.svelte'
+
+const { supabase, user } = Astro.locals
+
+// start of current week (Monday)
+const today = new Date()
+const currentWeekStart = new Date(today)
+currentWeekStart.setHours(0,0,0,0)
+currentWeekStart.setDate(currentWeekStart.getDate() - ((currentWeekStart.getDay() + 6) % 7))
+
+let posts, loadError
+try {
+  const { data, error } = await supabase
+    .from('game_posts_owner')
+    .select('*')
+    .gte('created_at', currentWeekStart.toISOString())
+    .or('audience.is.null,audience.eq.{}')
+    .order('created_at', { ascending: false })
+  if (error) { throw error }
+  posts = data
+} catch (err) {
+  loadError = 'Chyba načtení příspěvků: ' + err.message
+}
+---
+
+<Layout title='Příspěvek týdne'>
+  <h1>Hlasování o příspěvek týdne</h1>
+  {loadError ? <p>{loadError}</p> : (
+    <div>
+      {posts?.map((post) => <Post {post} {user} allowReactions allowedReactions={['hearts']} client:only='svelte' />)}
+    </div>
+  )}
+</Layout>


### PR DESCRIPTION
## Summary
- Allow components to limit available reactions
- Add "post of the week" voting page using heart reactions for votes
- Show Monday announcement with last week's winning post and link to voting

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint` *(fails: Missing script "lint" )*

------
https://chatgpt.com/codex/tasks/task_e_68c5a46ad09c832f9724dfe17efb4d0e