### PR TITLE
Render image resizing with percentage widths

### DIFF
--- a/src/components/common/Editor.svelte
+++ b/src/components/common/Editor.svelte
@@ -227,12 +227,23 @@
     fileInputEl.value = ''
   }
 
-  function addImageUrl () {
+  async function addImageUrl () {
     const url = window.prompt('Veřejná cesta k obrázku:')
-    if (url && (url.startsWith('https://') || url.startsWith('http://'))) {
-      editor.chain().focus().setImage({ src: url }).run()
-    } else {
+    if (!(url && (url.startsWith('https://') || url.startsWith('http://')))) {
       return window.alert('Obrázek musí být veřejně dostupný')
+    }
+
+    const img = new window.Image()
+    img.src = url
+
+    try {
+      await new Promise((resolve, reject) => {
+        img.onload = resolve
+        img.onerror = reject
+      })
+      editor.chain().focus().setImage({ src: url, width: img.naturalWidth || img.width, height: img.naturalHeight || img.height }).run()
+    } catch (error) {
+      editor.chain().focus().setImage({ src: url }).run()
     }
   }
 

--- a/src/lib/editor/image.js
+++ b/src/lib/editor/image.js
@@ -23,10 +23,10 @@ export const CustomImage = Image.extend({
       }
     }
     const alignmentStyle = getAlignmentStyle(node.attrs.alignment)
-    const imageWidth = node.attrs.width < this.editor.view.dom.offsetWidth ? node.attrs.width : this.editor.view.dom.offsetWidth
-    // const aspectRatio = node.attrs.height / node.attrs.width
-    const width = imageWidth ? `width: ${imageWidth * node.attrs.size / 100}px;` : ''
-    const sizeStyle = `${width} object-fit: contain; height: auto; max-width: 100%;` // height: fit-content is problematic in safari
+    const size = node.attrs.size ?? 100
+    const widthStyle = `width: ${size}%;`
+    const maxWidthStyle = node.attrs.width ? `max-width: ${node.attrs.width}px;` : 'max-width: 100%;'
+    const sizeStyle = `${widthStyle} ${maxWidthStyle} object-fit: contain; height: auto;` // height: fit-content is problematic in safari
     const style = `${alignmentStyle} ${sizeStyle}`
     return ['img', { ...HTMLAttributes, style }]
   },


### PR DESCRIPTION
## Summary
- update the custom image render logic to apply width resizing as percentages
- cap images to their intrinsic width while keeping responsive sizing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fa50a7f5d0832f95827d33ac6f47aa