### PR TITLE
Add published_at support for works listings

### DIFF
--- a/src/components/homepage/Latest.svelte
+++ b/src/components/homepage/Latest.svelte
@@ -29,7 +29,7 @@
     const { data: concepts, error: soloError } = await supabase.from('solo_concepts').select('*, author: profiles(id, name, portrait)').match({ published: true }).order('created_at', { ascending: false }).limit(5)
     if (soloError) { handleError(soloError) }
 
-    const { data: works, error: workError } = await supabase.from('work_list').select('*').match({ published: true }).order('created_at', { ascending: false }).not('editorial', 'eq', true).limit(5)
+    const { data: works, error: workError } = await supabase.from('work_list').select('*').match({ published: true }).order('published_at', { ascending: false, nullsLast: true }).not('editorial', 'eq', true).limit(5)
     if (workError) { handleError(workError) }
 
     const { data: boards, error: boardError } = await supabase.from('board_list').select('*').match({ published: true }).order('created_at', { ascending: false }).limit(5)

--- a/src/components/homepage/News.svelte
+++ b/src/components/homepage/News.svelte
@@ -5,7 +5,7 @@
     const { data: games, error: gameError } = await supabase.from('game_list').select('*').order('created_at', { ascending: false }).limit(3)
     if (gameError) { handleError(gameError) }
 
-    const { data: works, error: workError } = await supabase.from('work_list').select('*').order('created_at', { ascending: false }).not('editorial', 'eq', true).limit(3)
+    const { data: works, error: workError } = await supabase.from('work_list').select('*').order('published_at', { ascending: false, nullsLast: true }).not('editorial', 'eq', true).limit(3)
     if (workError) { handleError(workError) }
 
     const { data: boards, error: boardError } = await supabase.from('board_list').select('*').order('created_at', { ascending: false }).limit(3)
@@ -55,7 +55,7 @@
             {/if}
           </a>
           <div class='details'>
-            <span class='date'>{new Date(work.created_at).toLocaleDateString('cs')}</span>
+            <span class='date'>{new Date(work.published_at || work.created_at).toLocaleDateString('cs')}</span>
             <a href={'/user?id=' + work.owner} class='user'>{work.owner_name}</a>
           </div>
         </main>

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -296,6 +296,8 @@ create table works (
   editorial boolean default false,
   published boolean default false,
   created_at timestamp with time zone default current_timestamp,
+  updated_at timestamp with time zone default current_timestamp,
+  published_at timestamp with time zone,
   constraint works_owner_fkey foreign key (owner) references profiles (id) on delete set null
 );
 
@@ -583,7 +585,7 @@ create or replace view work_list as
     left join profiles pr on w.owner = pr.id
     left join posts p on t.id = p.thread
   group by w.id, pr.id, pr.name
-  order by w.created_at desc;
+  order by coalesce(w.published_at, w.created_at) desc;
 
 
 create or replace view game_messages as
@@ -1764,6 +1766,7 @@ create or replace trigger update_solo_concept_updated_at before update on solo_c
 -- Triggers for works
 create or replace trigger add_work_thread before insert on works for each row execute function add_thread();
 create or replace trigger delete_work_thread after delete on works for each row execute procedure delete_thread();
+create or replace trigger update_work_updated_at before update on works for each row execute procedure update_updated_at();
 -- Triggers for posts and messages
 create or replace trigger update_post_updated_at before update on posts for each row execute procedure update_post_updated_at();
 create or replace trigger update_message_updated_at before update on messages for each row execute procedure update_updated_at();

--- a/src/pages/api/import.js
+++ b/src/pages/api/import.js
@@ -240,7 +240,8 @@ async function migrateWork (workId, locals) {
       annotation: workData.annotation,
       tags: workData.tags,
       created_at: workData.post_date,
-      published: true
+      published: true,
+      published_at: workData.post_date
     }).select().single()
     if (error) throw new Error(`Failed to insert new work: ${error.message}`)
     if (!data) throw new Error('New work insertion failed without specific error.')

--- a/src/pages/api/work/approveWork.js
+++ b/src/pages/api/work/approveWork.js
@@ -6,7 +6,8 @@ export const GET = async ({ request, url, redirect, locals }) => {
 
   if (curatorIds.includes(locals.user.id)) {
     // approve work
-    const { error: approveError } = await locals.supabase.from('works').update({ published: true, created_at: (new Date()).toISOString() }).eq('id', workId)
+    const now = (new Date()).toISOString()
+    const { error: approveError } = await locals.supabase.from('works').update({ published: true, published_at: now }).eq('id', workId)
     if (approveError) { redirect(referer + '?toastType=error&toastText=' + encodeURIComponent('Schválení selhalo: ' + approveError.message)) }
 
     const { error: messageError } = await locals.supabase.from('messages').insert({

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -9,8 +9,8 @@
   const { supabase, user } = Astro.locals
 	const params = Object.fromEntries(Astro.url.searchParams)
 
-	try {
-		const res = await supabase.from('works').select('*').is('editorial', true).order('created_at', { ascending: false }).limit(1).maybeSingle()
+        try {
+                const res = await supabase.from('works').select('*').is('editorial', true).order('published_at', { ascending: false, nullsLast: true }).limit(1).maybeSingle()
 		if (res.error) { throw res.error }
 		lastEditorial = res.data
 	} catch (error) {


### PR DESCRIPTION
## Summary
- add published_at and updated_at fields to works along with update trigger and list view ordering
- update homepage listings to order works by publication date and display the publication timestamp
- ensure publishing flows populate published_at, including migrations and approvals

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932d8be4d08832fbc1d98d338ca3a53)