### PR TITLE
Filter NSFW solo AI posts out of homepage promo pools

### DIFF
--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -315,6 +315,7 @@ create table posts (
   identifier text,
   illustration text,
   moderated boolean default false,
+  nsfw boolean default false,
   dice boolean default false,
   created_at timestamp with time zone default current_timestamp,
   updated_at timestamp with time zone default current_timestamp,
@@ -636,7 +637,7 @@ create or replace view npc_posts_random as
 
 create materialized view game_showcase_pool as
   select
-    p.id, p.thread, p.owner, p.owner_type, p.content, p.audience, p.moderated, p.dice, p.created_at,
+    p.id, p.thread, p.owner, p.owner_type, p.content, p.audience, p.moderated, p.nsfw, p.dice, p.created_at,
     c.name as owner_name,
     c.portrait as owner_portrait,
     g.id as game_id,
@@ -651,6 +652,7 @@ create materialized view game_showcase_pool as
     and p.audience is null
     and p.dice is false
     and p.moderated is false
+    and coalesce(p.nsfw, false) is false
     and length(p.content) > 500
     and p.owner_type = 'character';
 
@@ -662,7 +664,8 @@ create or replace materialized view npc_posts_pool as
     join npcs on po.owner = npcs.id
     left join solo_concepts sc on npcs.solo_concept = sc.id
   where po.owner_type = 'npc'
-    and po.created_at >= now() - interval '1 month';
+    and po.created_at >= now() - interval '1 month'
+    and coalesce(po.nsfw, false) is false;
 
 
 -- FUNCTIONS --------------------------------------------

--- a/src/lib/solo/solo.js
+++ b/src/lib/solo/solo.js
@@ -91,7 +91,10 @@ Tvým cílem je vést příběh podle "Plánu hry". Každá odpověď by měla p
 Pokud plán hry v kontextu chybí, napiš "<p class='info'>Plán hry není k dispozici, pokračuji improvizací</p>".
 
 Konec hry:
-Pokud postava zemře, nebo se příběh dostane do konceptem definovaného konce, popiš uspokojivě závěr hry a nastav "end" na true. Jinak pole vynech.`
+Pokud postava zemře, nebo se příběh dostane do konceptem definovaného konce, popiš uspokojivě závěr hry a nastav "end" na true. Jinak pole vynech.
+
+Bezpečnost obsahu:
+Pokud odpověď obsahuje sexuálně explicitní nebo jinak potenciálně problematický NSFW obsah, nastav pole "nsfw" na true. Pokud takový obsah neobsahuje, nastav "nsfw" na false.`
 
 export const fieldNames = { prompt_world: 'Svět', prompt_factions: 'Frakce', prompt_locations: 'Lokace', prompt_characters: 'Postavy', prompt_protagonist: 'Postava hráče', prompt_plan: 'Plán hry', prompt_header_image: 'Ilustrační obrázek', prompt_storyteller_image: 'Portrét vypravěče', protagonist_names: 'Jména postavy', annotation: 'Reklamní text', first_image: 'Obrázek první scény', protagonist_image: 'Portrét postavy', inventory: 'Inventář postavy', abilities: 'Schopnosti postavy' }
 
@@ -146,8 +149,12 @@ export const getResponseSchema = (illustrationStyleAffix) => {
       end: {
         type: 'BOOLEAN',
         description: 'Pokud tímto příspěvkem hra skončila, nastav na true. Například pokud postava zemřela. Jinak ponech false, nebo pole vynechej.'
+      },
+      nsfw: {
+        type: 'BOOLEAN',
+        description: 'Nastav na true, pokud příspěvek obsahuje sexuálně explicitní nebo jinak potenciálně problematický NSFW obsah. Jinak nastav na false.'
       }
     },
-    required: ['post', 'character', 'scene']
+    required: ['post', 'character', 'scene', 'nsfw']
   }
 }

--- a/src/pages/api/solo/createGame.js
+++ b/src/pages/api/solo/createGame.js
@@ -87,7 +87,7 @@ export const GET = async ({ request, locals, redirect }) => {
     }
 
     // Save the first post
-    const { error: addPostError } = await locals.supabase.from('posts').insert({ thread: gameData.thread, content: firstPost.post, owner_type: 'npc', owner: concept.storyteller, identifier: getStamp() })
+    const { error: addPostError } = await locals.supabase.from('posts').insert({ thread: gameData.thread, content: firstPost.post, owner_type: 'npc', owner: concept.storyteller, identifier: getStamp(), nsfw: firstPost.nsfw === true })
     if (addPostError) { throw new Error(addPostError.message) }
 
     // Return success object

--- a/src/pages/api/solo/generatePost.js
+++ b/src/pages/api/solo/generatePost.js
@@ -15,7 +15,7 @@ export const POST = async ({ request, locals }) => {
       if (!postData || !postData.post || !postData.post.trim()) {
         throw new Error('Cannot save empty post content')
       }
-      const { error: postError } = await locals.supabase.from('posts').insert({ thread, owner: ownerId, owner_type: ownerType, content: postData.post, identifier: postHash, illustration: postData.illustration })
+      const { error: postError } = await locals.supabase.from('posts').insert({ thread, owner: ownerId, owner_type: ownerType, content: postData.post, identifier: postHash, illustration: postData.illustration, nsfw: postData.nsfw === true })
       if (postError) { throw new Error('Chyba při ukládání příspěvku: ' + postError.message) }
 
       // update solo_limit for the user


### PR DESCRIPTION
### Motivation
- Prevent NSFW content generated by the solo AI from surfacing as homepage promo posts taken from the promo pools.
- Make the AI explicitly mark potentially problematic outputs so the server can persist and act on that flag.

### Description
- Database: added `nsfw boolean default false` column to `posts` and propagated that field into `game_showcase_pool` selection, while filtering out NSFW entries from both `game_showcase_pool` and `npc_posts_pool`. (`src/db/schema.sql`)
- AI contract: extended the storyteller instructions to ask the model to set an `nsfw` boolean and added `nsfw` to the structured response schema as a required field. (`src/lib/solo/solo.js`)
- Persistence: when inserting AI-generated posts the server now persists the `nsfw` flag (`nsfw: ... === true`) for the initial solo game post and for streamed/generated solo posts. (`src/pages/api/solo/createGame.js`, `src/pages/api/solo/generatePost.js`)

### Testing
- Built the project to validate syntax and bundling with `npm run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699087fa8c50832f9f6e4a3370aab765)