### PR TITLE
Validate work title on creation and show only published works on profile

### DIFF
--- a/src/components/works/WorkForm.svelte
+++ b/src/components/works/WorkForm.svelte
@@ -53,7 +53,7 @@
         <label for='workName'>Název</label>
       </div>
       <div class='inputs'>
-        <input type='text' id='workName' name='workName' maxlength='80' onkeydown={preventSubmit} />
+        <input type='text' id='workName' name='workName' maxlength='80' required onkeydown={preventSubmit} />
       </div>
     </div>
 

--- a/src/pages/user.astro
+++ b/src/pages/user.astro
@@ -24,7 +24,7 @@
   data.boards = boards
 
   // load user's works
-  const { data: works, error: worksError } = await supabase.from('work_list').select('*').eq('owner', userId)
+  const { data: works, error: worksError } = await supabase.from('work_list').select('*').eq('owner', userId).eq('published', true)
   if (worksError) { console.error('error loading user works', worksError) }
   data.works = works
 ---

--- a/src/pages/work/work-form.astro
+++ b/src/pages/work/work-form.astro
@@ -7,7 +7,7 @@
 
   if (Astro.request.method === 'POST') {
     const formData = await Astro.request.formData()
-    const name = formData.get('workName')
+    const name = formData.get('workName')?.trim()
     const annotation = formData.get('workAnnotation')
     const category = formData.get('workCategory')
     const tags = formData.get('workTags') ? formData.get('workTags').split(',') : []
@@ -32,6 +32,10 @@
       }
 
       content = formType === 'image' ? JSON.stringify(uploadedPaths) : uploadedPaths[0]
+    }
+
+    if (!name) {
+      return Astro.redirect(`/?toastType=error&toastText=${encodeURIComponent('Název díla je povinný')}`)
     }
 
     const { data, error } = await supabase.from('works').insert({ owner: user.id, name, category, content, annotation, tags, type: formType }).select().single()


### PR DESCRIPTION
### Motivation
- Prevent creation of works without a name and ensure profiles don't display deleted/unpublished works.

### Description
- Trim and validate the submitted work name in the server POST handler and reject empty names with an error redirect in `src/pages/work/work-form.astro`.
- Add `required` HTML attribute to the work name input in `src/components/works/WorkForm.svelte` to enforce client-side validation.
- Filter profile work queries to only include published works by adding `.eq('published', true)` when loading works in `src/pages/user.astro`.

### Testing
- Ran a production build with `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db8ef95354832f9b1070aa3fded85f)