### PR TITLE
Aktualizovat `created_at` při schválení díla

### DIFF
--- a/src/pages/api/work/approveWork.js
+++ b/src/pages/api/work/approveWork.js
@@ -7,7 +7,7 @@ export const GET = async ({ request, url, redirect, locals }) => {
   if (curatorIds.includes(locals.user.id)) {
     // approve work
     const now = (new Date()).toISOString()
-    const { error: approveError } = await locals.supabase.from('works').update({ published: true, published_at: now }).eq('id', workId)
+    const { error: approveError } = await locals.supabase.from('works').update({ published: true, published_at: now, created_at: now }).eq('id', workId)
     if (approveError) { redirect(referer + '?toastType=error&toastText=' + encodeURIComponent('Schválení selhalo: ' + approveError.message)) }
 
     const { error: messageError } = await locals.supabase.from('messages').insert({


### PR DESCRIPTION
### Motivation
- Při schválení díla v seznamu `/works` má datum přidání (`created_at`) odpovídat času schválení, nikoli původnímu vytvoření; proto je potřeba ho přenastavit.

### Description
- V souboru `src/pages/api/work/approveWork.js` se při schválení nyní provádí update řádku v tabulce `works`, který kromě `published: true` a `published_at: now` také nastaví `created_at: now`.

### Testing
- Spuštěno `npm run build` a build proběhl úspěšně bez chyb.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e89e77c604832fb17ef8e6103fe577)