### PR TITLE
Fix /user 500 when requested profile does not exist

### DIFF
--- a/src/pages/user.astro
+++ b/src/pages/user.astro
@@ -5,30 +5,44 @@
   const { supabase, user } = Astro.locals
 
   const userId = Astro.url.searchParams.get('id')
-  const { data, error } = await supabase.from('profiles').select('*').eq('id', userId).single()
-  if (error) { console.error('error loading user profile', error) }
+  let data = null
 
-  // load user's games
-  const { data: games, error: gamesError } = await supabase.from('game_list').select('*').eq('owner', userId)
-  if (gamesError) { console.error('error loading user games', gamesError) }
-  data.games = games
+  if (userId) {
+    const { data: profileData, error } = await supabase.from('profiles').select('*').eq('id', userId).maybeSingle()
+    if (error) { console.error('error loading user profile', error) }
+    data = profileData
+  }
 
-  // load user's concepts
-  const { data: concepts, error: conceptsError } = await supabase.from('solo_concepts').select('*, author: profiles(id, name, portrait)').eq('author', userId)
-  if (conceptsError) { console.error('error loading user concepts', conceptsError) }
-  data.concepts = concepts
+  if (!data) {
+    Astro.response.status = 404
+  } else {
+    // load user's games
+    const { data: games, error: gamesError } = await supabase.from('game_list').select('*').eq('owner', userId)
+    if (gamesError) { console.error('error loading user games', gamesError) }
+    data.games = games || []
 
-  // load user's boards
-  const { data: boards, error: boardsError } = await supabase.from('board_list').select('*').eq('owner', userId)
-  if (boardsError) { console.error('error loading user boards', boardsError) }
-  data.boards = boards
+    // load user's concepts
+    const { data: concepts, error: conceptsError } = await supabase.from('solo_concepts').select('*, author: profiles(id, name, portrait)').eq('author', userId)
+    if (conceptsError) { console.error('error loading user concepts', conceptsError) }
+    data.concepts = concepts || []
 
-  // load user's works
-  const { data: works, error: worksError } = await supabase.from('work_list').select('*').eq('owner', userId).eq('published', true)
-  if (worksError) { console.error('error loading user works', worksError) }
-  data.works = works
+    // load user's boards
+    const { data: boards, error: boardsError } = await supabase.from('board_list').select('*').eq('owner', userId)
+    if (boardsError) { console.error('error loading user boards', boardsError) }
+    data.boards = boards || []
+
+    // load user's works
+    const { data: works, error: worksError } = await supabase.from('work_list').select('*').eq('owner', userId).eq('published', true)
+    if (worksError) { console.error('error loading user works', worksError) }
+    data.works = works || []
+  }
 ---
 
-<Layout title={data.name}>
-  <Profile {data} {user} client:only='svelte' />
+<Layout title={data?.name || 'Uživatel nenalezen'}>
+  {data
+    ? <Profile {data} {user} client:only='svelte' />
+    : <>
+    <h1>Uživatel nenalezen</h1>
+    <p>Požadovaný profil neexistuje nebo už byl odstraněn.</p>
+    </>}
 </Layout>


### PR DESCRIPTION
### Motivation
- The `/user` page could crash with `Cannot set properties of null (setting 'games')` when a profile row was missing, causing 500 errors for crawlers or stale links.
- The code assumed `data` from the `profiles` query was always present and then unconditionally assigned related collections onto it.
- The change prevents a runtime crash and returns a proper 404 when the profile is absent.

### Description
- Replaced the `profiles` lookup `.single()` call with `maybeSingle()` and store result in a local `data` variable to avoid throwing on missing rows in `src/pages/user.astro`.
- Added a guard that sets `Astro.response.status = 404` and renders a simple "Uživatel nenalezen" fallback when no profile is found.
- Only load related collections (`game_list`, `solo_concepts`, `board_list`, `work_list`) when the profile exists and normalize them to empty arrays (`[]`) to avoid null propagation.
- Updated template to use `data?.name` for the page title and conditionally render the profile component or the fallback message.

### Testing
- Ran `npm run build`; the first build failed due to an introduced template syntax mistake which was corrected immediately. (failure observed, fix applied)
- Ran `npm run build` again after fixes and it completed successfully (build passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef4131ed48832fb94079ae2641e1fd)