### PR TITLE
Add Discussion and thread support to solo concepts

### DIFF
--- a/src/components/solo/Concept.svelte
+++ b/src/components/solo/Concept.svelte
@@ -8,6 +8,7 @@
   import { getPortraitUrl } from '@lib/database-browser'
   import { illustrationStyles } from '@lib/solo/solo'
   import { supabase, handleError } from '@lib/database-browser'
+  import Discussion from '@components/Discussion.svelte'
   import Loading from '@components/common/Loading.svelte'
   import StarRatingInput from '@components/solo/StarRatingInput.svelte'
 
@@ -337,6 +338,10 @@
       {/if}
     </aside>
   </div>
+  {#if concept.thread}
+    <br><br>
+    <Discussion data={concept} {user} thread={concept.thread} canModerate={concept.author.id === user.id} unread={concept.unread} slug={'solo-concept-' + concept.id} contentSection='solo' />
+  {/if}
 {/if}
 
 <style>

--- a/src/db/policies.sql
+++ b/src/db/policies.sql
@@ -157,8 +157,9 @@ OR thread in (
     OR exists (select 1 from boards where boards.open = true AND boards.thread = posts.thread AND NOT ((select auth.uid()) = any (boards.bans)))
     -- Closed boards for members
     OR exists (select 1 from boards where boards.open = false AND boards.thread = posts.thread AND ((select auth.uid()) = boards.owner OR (select auth.uid()) = any (boards.members) OR (select auth.uid()) = any (boards.mods)))
-    -- Posts in works
+    -- Posts in works and solo concepts
     OR thread in (select thread from works)
+    OR thread in (select thread from solo_concepts)
   );
 
 -- Consolidated INSERT policy
@@ -172,8 +173,8 @@ create policy "posts_insert_policy" on public.posts
     OR thread = 1
     -- Player in solo game
     OR thread in (select thread from solo_games where player = (select auth.uid()))
-    -- Players can insert in board/work/game threads
-    OR thread in (select thread from boards union select thread from works union select discussion_thread as thread from games where is_player(id) union select game_thread as thread from games where is_player(id))
+    -- Players can insert in board/work/solo concept/game threads
+    OR thread in (select thread from boards union select thread from works union select thread from solo_concepts union select discussion_thread as thread from games where is_player(id) union select game_thread as thread from games where is_player(id))
     -- Storytellers in their games
 OR thread in (
   select g.game_thread from games g
@@ -188,8 +189,9 @@ OR thread in (
 )
     -- Mods and owners in boards
     OR exists (select 1 from boards where boards.thread = posts.thread AND ((select auth.uid()) = boards.owner OR (select auth.uid()) = any (boards.mods)))
-    -- Work owners
+    -- Work and solo concept owners
     OR thread in (select thread from works where owner = (select auth.uid()))
+    OR thread in (select thread from solo_concepts where author = (select auth.uid()))
   );
 
 -- Consolidated UPDATE policy
@@ -215,8 +217,9 @@ OR thread in (
 )
     -- Mods and owners in boards
     OR exists (select 1 from boards where boards.thread = posts.thread AND ((select auth.uid()) = boards.owner OR (select auth.uid()) = any (boards.mods)))
-    -- Work owners
+    -- Work and solo concept owners
     OR thread in (select thread from works where owner = (select auth.uid()))
+    OR thread in (select thread from solo_concepts where author = (select auth.uid()))
   );
 
 -- Consolidated DELETE policy
@@ -242,8 +245,9 @@ OR thread in (
 )
     -- Mods and owners in boards
     OR exists (select 1 from boards where boards.thread = posts.thread AND ((select auth.uid()) = boards.owner OR (select auth.uid()) = any (boards.mods)))
-    -- Work owners
+    -- Work and solo concept owners
     OR thread in (select thread from works where owner = (select auth.uid()))
+    OR thread in (select thread from solo_concepts where author = (select auth.uid()))
   );
 
 

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -165,6 +165,8 @@ create table solo_concepts (
   published boolean default false,
   created_at timestamp with time zone default current_timestamp,
   updated_at timestamp with time zone default current_timestamp,
+  thread int4,
+  constraint solo_concepts_thread_fkey foreign key (thread) references threads(id) on delete cascade,
   constraint solo_concepts_st_fkey foreign key (storyteller) references npcs(id) on delete set null,
   constraint solo_concepts_author_fkey foreign key (author) references profiles(id) on delete cascade
 );
@@ -1151,6 +1153,8 @@ select exists (
   select 1 from games where (discussion_thread = thread_id or game_thread = thread_id) and owner = auth.uid()
   union all
   select 1 from works where thread = thread_id and owner = auth.uid()
+  union all
+  select 1 from solo_concepts where thread = thread_id and author = auth.uid()
 );
 $$ language sql security definer;
 
@@ -1803,6 +1807,8 @@ create or replace trigger delete_board_thread after delete on boards for each ro
 -- Triggers for solo games
 create or replace trigger add_solo_game_thread before insert on solo_games for each row execute function add_thread();
 create or replace trigger delete_solo_game_thread after delete on solo_games for each row execute procedure delete_thread();
+create or replace trigger add_solo_concept_thread before insert on solo_concepts for each row execute function add_thread();
+create or replace trigger delete_solo_concept_thread after delete on solo_concepts for each row execute procedure delete_thread();
 create or replace trigger update_solo_concept_updated_at before update on solo_concepts for each row execute procedure update_updated_at();
 -- Triggers for works
 create or replace trigger add_work_thread before insert on works for each row execute function add_thread();

--- a/src/pages/solo/concept/[conceptId]/index.astro
+++ b/src/pages/solo/concept/[conceptId]/index.astro
@@ -9,6 +9,29 @@
 
   const { data: concept, error } = await supabase.from('solo_concepts').select('*, author:profiles(*)').eq('id', conceptId).single();
   if (error) { return Astro.redirect(`/?toastType=error&toastText=${encodeURIComponent('Chyba: ' + error.message)}`) }
+
+  if (!concept.thread) {
+    const { data: threadData, error: threadError } = await supabase.from('threads').insert({ name: concept.name }).select('id').single()
+    if (threadError) { return Astro.redirect(`/?toastType=error&toastText=${encodeURIComponent('Chyba: ' + threadError.message)}`) }
+
+    const { error: conceptThreadError } = await supabase.from('solo_concepts').update({ thread: threadData.id }).eq('id', concept.id)
+    if (conceptThreadError) { return Astro.redirect(`/?toastType=error&toastText=${encodeURIComponent('Chyba: ' + conceptThreadError.message)}`) }
+    concept.thread = threadData.id
+
+    if (user.id) {
+      const { error: readError } = await supabase.from('read_threads').upsert({ user_id: user.id, thread_id: concept.thread, read_at: new Date().toISOString() }, { onConflict: 'user_id, thread_id' })
+      if (readError) { return Astro.redirect(`/?toastType=error&toastText=${encodeURIComponent('Chyba: ' + readError.message)}`) }
+
+      const { error: unreadInitError } = await supabase.from('unread_threads').upsert({ user_id: user.id, thread_id: concept.thread, unread_count: 0 }, { onConflict: 'user_id, thread_id' })
+      if (unreadInitError) { return Astro.redirect(`/?toastType=error&toastText=${encodeURIComponent('Chyba: ' + unreadInitError.message)}`) }
+    }
+  }
+
+  if (user.id) {
+    const { data: unreadData, error: unreadError } = await supabase.from('unread_threads').select('unread_count').match({ user_id: user.id, thread_id: concept.thread }).maybeSingle()
+    if (unreadError) { return Astro.redirect(`/?toastType=error&toastText=${encodeURIComponent('Chyba: ' + unreadError.message)}`) }
+    if (unreadData) { concept.unread = unreadData?.unread_count || 0 }
+  }
 ---
 
 <Layout title={concept?.name} headerStorage={concept?.custom_header ? `solo-${concept.id}.jpg?hash=${concept.custom_header}` : null}>


### PR DESCRIPTION
### Motivation
- Enable discussions for solo concept pages using the shared `Discussion` component so concepts behave like works with threaded posts. 
- Ensure existing concepts without a discussion thread get a thread created and have read/unread tracking initialized. 
- Update database schema, triggers and RLS policies so solo concept threads can be posted to and moderated safely like work threads.

### Description
- Import and render the `Discussion` component in `src/components/solo/Concept.svelte` and show it when `concept.thread` is present. 
- Lazily create a thread for concepts that lack one and initialize read/unread rows and load the unread count in `src/pages/solo/concept/[conceptId]/index.astro`. 
- Add a `thread` column with FK to `threads` in `src/db/schema.sql`, add create/delete triggers for solo concept threads, and extend `is_thread_owner` to include `solo_concepts`. 
- Update `src/db/policies.sql` to include `solo_concepts` in the `posts` select/insert/update/delete policies so posting and moderation follow the same rules as works.

### Testing
- Ran `npm run build`, which completed successfully. 
- Ran `git diff --check` and repository checks with the build; no issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18d0039f90832fbdbcaadda1b5b2fe)