### PR TITLE
Prevent empty board names

### DIFF
--- a/src/components/boards/BoardForm.svelte
+++ b/src/components/boards/BoardForm.svelte
@@ -11,7 +11,7 @@
   <form method='POST' autocomplete='off'>
     <div class='row'>
       <div class='labels'><label for='boardName'>Název</label></div>
-      <div class='inputs'><input type='text' id='boardName' name='boardName' maxlength='80' onkeydown={preventSubmit} /></div>
+      <div class='inputs'><input type='text' id='boardName' name='boardName' maxlength='80' required onkeydown={preventSubmit} /></div>
     </div>
 
     <div class='row'>

--- a/src/pages/board/board-form.astro
+++ b/src/pages/board/board-form.astro
@@ -6,8 +6,10 @@
 
   if (Astro.request.method === 'POST') {
     const formData = await Astro.request.formData()
-    const boardName = formData.get('boardName')
+    const boardName = String(formData.get('boardName') || '').trim()
     const boardAnnotation = formData.get('boardAnnotation')
+
+    if (!boardName) { return Astro.redirect(`/board/board-form?toastType=error&toastText=${encodeURIComponent('Chyba: Prosím vyplň název diskuze.')}`) }
 
     // Check if the board name already exists
     const { data: existingBoard, error: checkError } = await supabase.from('boards').select('name').eq('name', boardName).single()


### PR DESCRIPTION
### Motivation

- Prevent creating a discussion (board) with an empty or whitespace-only name by validating on the server and improving client-side validation.
- Provide a clear error toast when submission is invalid and avoid inserting blank board records.

### Description

- Trim and normalize the submitted board name using `String(formData.get('boardName') || '').trim()` and reject empty values with an early redirect and error toast in `src/pages/board/board-form.astro`.
- Add the `required` attribute to the board name input in `src/components/boards/BoardForm.svelte` to enable browser-side validation before submit.
- Modified files: `src/pages/board/board-form.astro`, `src/components/boards/BoardForm.svelte`.

### Testing

- Ran `npm run build` which completed successfully.
- Ran `git diff --check`/basic repository checks which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d69a16dd4832fa4eb344521593ace)