### PR TITLE
Aktualizace modelu Kimi na `kimi-k2.6`

### DIFF
--- a/src/lib/solo/server-moonshot.js
+++ b/src/lib/solo/server-moonshot.js
@@ -1,7 +1,7 @@
 import OpenAI from 'openai'
 
 export const getStorytellerParams = () => {
-  return { model: 'kimi-k2-0905-preview', response_format: { type: 'json_object' } }
+  return { model: 'kimi-k2.6', response_format: { type: 'json_object' } }
 }
 
 export function getAI (env) {

--- a/src/pages/api/game/generatePost.js
+++ b/src/pages/api/game/generatePost.js
@@ -26,7 +26,7 @@ export const POST = async ({ locals, request }) => {
     }
   ]
 
-  const completion = await ai.chat.completions.create({ model: 'kimi-k2-0905-preview', messages, stream: true }, { signal: request.signal })
+  const completion = await ai.chat.completions.create({ model: 'kimi-k2.6', messages, stream: true }, { signal: request.signal })
   const stream = await getReadableStream(completion)
 
   // Return stream response


### PR DESCRIPTION
### Motivation
- Aktualizace používaného Moonshot/Kimi modelu na novější verzi `kimi-k2.6` pro generování herních příspěvků a storyteller výstupů.

### Description
- Změněn návrat hodnoty `getStorytellerParams` tak, aby vracela `{ model: 'kimi-k2.6', response_format: { type: 'json_object' } }` v `src/lib/solo/server-moonshot.js`.
- Aktualizován volací parametr modelu v streamovaném dokončování v `src/pages/api/game/generatePost.js` na `kimi-k2.6`.
- Změny jsou pouze textové náhrady řetězce modelu bez dalších funkčních úprav logiky streamování.

### Testing
- Spuštěno `npm run build` a sestavení projektu proběhlo úspěšně.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d80c4ff8c832f90ac222a4e321a09)